### PR TITLE
Allows document _id to be generated on driver side for return

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2257,5 +2257,5 @@
         "ext-mongodb": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/MongoClient.php
+++ b/src/MongoClient.php
@@ -376,6 +376,8 @@ class MongoClient
             $docObj->{$key} = $value;
         }
 
+        $docObj->_id ??= new BSON\ObjectId();
+
         $this->query(array_merge([
             MongoCommand::INSERT => $collection,
             'documents' => [$docObj],


### PR DESCRIPTION
In insert, generate `BSON\ObjectId` if one doesn't exist in document, and insert it, instead of letting server generate _id.