### PR TITLE
Enhance unique index handling in Client class to prevent sparse index…

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -404,8 +404,11 @@ class Client
             if (\array_key_exists('unique', $index) && $index['unique'] == true) {
                 /**
                  * TODO: Unique Indexes are now sparse indexes, which results into incomplete indexes.
+                 * However, if partialFilterExpression is present, we can't use sparse.
                  */
-                $indexes[$key] = \array_merge($index, ['sparse' => true]);
+                if (!\array_key_exists('partialFilterExpression', $index)) {
+                    $indexes[$key] = \array_merge($index, ['sparse' => true]);
+                }
             }
         }
 


### PR DESCRIPTION
… usage when partialFilterExpression is present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted unique index creation: the sparse option is only applied when no partial filter is provided, preventing conflicts and aligning with expected database behavior.
  * Improves accuracy of index definitions and avoids errors when creating unique indexes with partialFilterExpression.
  * Existing behavior remains unchanged for indexes without partial filters; no configuration changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->