### PR TITLE
Throw BulkWriteException with write results on write errors

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1634,8 +1634,12 @@ class Client
 
             // Check for write errors (duplicate key, etc.)
             if (\property_exists($result, 'writeErrors') && !empty($result->writeErrors)) {
-                throw new Exception(
+                throw new BulkWriteException(
                     $result->writeErrors[0]->errmsg,
+                    [
+                        'writeErrors' => $result->writeErrors,
+                        'nInserted' => $result->n ?? 0,
+                    ],
                     $result->writeErrors[0]->code
                 );
             }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -243,7 +243,7 @@ class BulkWriteException extends Exception
 
     public function __construct(string $message, array $result, int $code = 0, ?\Throwable $previous = null)
     {
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, $code, $previous, [], $result['writeErrors'] ?? null);
         $this->result = $result;
     }
 

--- a/tests/MongoTest.php
+++ b/tests/MongoTest.php
@@ -5,6 +5,7 @@ namespace Utopia\Tests;
 use MongoDB\BSON\ObjectId;
 use PHPUnit\Framework\TestCase;
 use Utopia\Mongo\Client;
+use Utopia\Mongo\BulkWriteException;
 use Utopia\Mongo\Exception;
 
 class MongoTest extends TestCase
@@ -473,6 +474,46 @@ class MongoTest extends TestCase
                 ['$count' => 'total']
             ]);
             self::assertEquals(6, $complexOrAggregationResult->cursor->firstBatch[0]->total);
+        } finally {
+            $this->getDatabase()->dropCollection($collectionName);
+        }
+    }
+
+    public function testInsertManyDuplicateThrowsBulkWriteException(): void
+    {
+        $collectionName = 'test_bulk_write_exception';
+        $this->getDatabase()->createCollection($collectionName);
+
+        try {
+            // Insert a doc with explicit _id
+            $this->getDatabase()->insert($collectionName, [
+                '_id' => 'dup_id',
+                'name' => 'Original',
+            ]);
+
+            // insertMany with a duplicate _id should throw BulkWriteException
+            try {
+                $this->getDatabase()->insertMany($collectionName, [
+                    ['_id' => 'dup_id', 'name' => 'Duplicate'],
+                    ['_id' => 'new_id', 'name' => 'New'],
+                ], ['ordered' => false]);
+
+                self::fail('Expected BulkWriteException');
+            } catch (BulkWriteException $e) {
+                // Should be a duplicate key error
+                self::assertSame(11000, $e->getCode());
+
+                $result = $e->getResult();
+                self::assertArrayHasKey('nInserted', $result);
+                self::assertArrayHasKey('writeErrors', $result);
+                self::assertGreaterThanOrEqual(1, $result['nInserted']);
+            }
+
+            // 'new_id' should have been inserted despite the duplicate (ordered: false)
+            $found = $this->getDatabase()->find($collectionName, ['_id' => 'new_id']);
+            $docs = $found->cursor->firstBatch ?? [];
+            self::assertCount(1, $docs);
+            self::assertSame('New', $docs[0]->name);
         } finally {
             $this->getDatabase()->dropCollection($collectionName);
         }

--- a/tests/MongoTest.php
+++ b/tests/MongoTest.php
@@ -506,7 +506,7 @@ class MongoTest extends TestCase
                 $result = $e->getResult();
                 self::assertArrayHasKey('nInserted', $result);
                 self::assertArrayHasKey('writeErrors', $result);
-                self::assertGreaterThanOrEqual(1, $result['nInserted']);
+                self::assertSame(1, $result['nInserted']);
             }
 
             // 'new_id' should have been inserted despite the duplicate (ordered: false)


### PR DESCRIPTION
## Summary

- Throws `BulkWriteException` (already exists but was unused) instead of generic `Exception` when `writeErrors` are returned from MongoDB
- Includes `nInserted` count and full `writeErrors` array in the exception result, accessible via `$e->getResult()`
- Enables callers (e.g. `utopia-php/database` Mongo adapter) to recover partial success info from `insertMany` with `ordered: false`

## Test plan

- [x] Added `testInsertManyDuplicateThrowsBulkWriteException` — verifies `BulkWriteException` is thrown with correct `nInserted` and `writeErrors`, and that non-duplicate docs persist with `ordered: false`
- [ ] Existing tests pass (exception type is a subclass of `Exception`, so catches still work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk-write error handling to return detailed error information (message, code, error list) and operation stats (number of documents inserted).
* **Tests**
  * Added a test covering unordered bulk inserts with duplicate keys, asserting detailed error payload and that non-duplicate documents are still persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->