### PR TITLE
feat: add upsertWithCounts() with separate matched/upserted counts

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -243,10 +243,14 @@ class Client
      *
      * @param array<string, mixed> $command Command to execute
      * @param string|null $db Database name
+     * @param bool $returnRaw When true, skip the int/extracted-field short-circuits
+     *                        in the response parser and return the full stdClass
+     *                        result — use when the caller needs fields beyond `n`
+     *                        (e.g. the `upserted` array from an update command).
      * @return stdClass|array|int Query result
      * @throws Exception
      */
-    public function query(array $command, ?string $db = null): stdClass|array|int
+    public function query(array $command, ?string $db = null, bool $returnRaw = false): stdClass|array|int
     {
         // Validate connection state before each operation
         $this->validateConnection();
@@ -351,7 +355,7 @@ class Client
 
         $sections = Document::fromPHP($params);
         $message = pack('V*', 21 + strlen($sections), $this->id, 0, 2013, 0) . "\0" . $sections;
-        $result = $this->send($message);
+        $result = $this->send($message, $returnRaw);
 
         $this->updateCausalConsistency($result);
 
@@ -371,7 +375,7 @@ class Client
      * @return stdClass|array|int
      * @throws Exception
      */
-    public function send(mixed $data): stdClass|array|int
+    public function send(mixed $data, bool $returnRaw = false): stdClass|array|int
     {
         // Check if connection is alive, connect if not
         if (!$this->client->isConnected()) {
@@ -390,14 +394,14 @@ class Client
             }
         }
 
-        return $this->receive();
+        return $this->receive($returnRaw);
     }
 
     /**
      * Receive a message from connection.
      * @throws Exception
      */
-    private function receive(): stdClass|array|int
+    private function receive(bool $returnRaw = false): stdClass|array|int
     {
         $chunks = [];
         $receivedLength = 0;
@@ -461,7 +465,7 @@ class Client
 
         $res = \implode('', $chunks);
 
-        return $this->parseResponse($res, $responseLength);
+        return $this->parseResponse($res, $responseLength, $returnRaw);
     }
 
     /**
@@ -897,6 +901,81 @@ class Client
                 $options
             )
         );
+    }
+
+    /**
+     * Execute a batch of upserts and return detailed counts from the response.
+     *
+     * Unlike {@see upsert()}, which returns the raw `n` field (matched + upserted),
+     * this method separates matched-existing from newly-upserted documents so the
+     * caller can tell exactly which operations produced new docs. Useful for
+     * `skipDuplicates`-style callers that need to report "actually inserted" counts.
+     *
+     * @param string $collection
+     * @param array<int, array{filter: array<string, mixed>, update: array<string, mixed>, multi?: bool}> $operations
+     * @param array<string, mixed> $options
+     *
+     * @return array{
+     *     matched: int,
+     *     modified: int,
+     *     upserted: array<int, array{index: int, _id: mixed}>
+     * } Response counts. `matched` is the number of pre-existing docs matched
+     *   by a filter (derived as `n - count(upserted)` since MongoDB's `n`
+     *   includes upserts). `modified` is docs whose contents changed. `upserted`
+     *   is the list of newly-created docs, each carrying the source operation's
+     *   `index` and the assigned `_id`.
+     *
+     * @throws Exception
+     */
+    public function upsertWithCounts(string $collection, array $operations, array $options = []): array
+    {
+        $updates = [];
+
+        foreach ($operations as $op) {
+            $updates[] = [
+                'q' => $op['filter'],
+                'u' => $this->toObject($op['update']),
+                'upsert' => true,
+                'multi' => $op['multi'] ?? false,
+            ];
+        }
+
+        $result = $this->query(
+            array_merge(
+                [
+                    self::COMMAND_UPDATE => $collection,
+                    'updates' => $updates,
+                ],
+                $options
+            ),
+            null,
+            true // $returnRaw — we need the full response, not just $result->n
+        );
+
+        if (!$result instanceof stdClass) {
+            throw new Exception('Unexpected upsertWithCounts response: expected stdClass, got ' . \gettype($result));
+        }
+
+        $upserted = [];
+        if (\property_exists($result, 'upserted') && \is_iterable($result->upserted)) {
+            foreach ($result->upserted as $entry) {
+                $upserted[] = [
+                    'index' => (int) $entry->index,
+                    '_id' => $entry->_id,
+                ];
+            }
+        }
+
+        // MongoDB's `n` in the update response = matched-existing + upserted-new.
+        // Subtract the upserts so `matched` reflects only pre-existing docs.
+        $n = (int) ($result->n ?? 0);
+        $matched = \max(0, $n - \count($upserted));
+
+        return [
+            'matched' => $matched,
+            'modified' => (int) ($result->nModified ?? 0),
+            'upserted' => $upserted,
+        ];
     }
 
 
@@ -1584,7 +1663,7 @@ class Client
      * @return stdClass|array|int Parsed response
      * @throws Exception
      */
-    private function parseResponse(string $response, int $responseLength): stdClass|array|int
+    private function parseResponse(string $response, int $responseLength, bool $returnRaw = false): stdClass|array|int
     {
         /*
          * The first 21 bytes of the MongoDB wire protocol response consist of:
@@ -1646,6 +1725,12 @@ class Client
                     'E' . $result->code . ' ' . $result->codeName . ': ' . $result->errmsg,
                     $result->code
                 );
+            }
+
+            // Callers that need the full response object (e.g. to read the
+            // `upserted` array from an update command) opt in with $returnRaw.
+            if ($returnRaw && $result->ok === 1.0) {
+                return $result;
             }
 
             // Check for operation success

--- a/src/Client.php
+++ b/src/Client.php
@@ -929,6 +929,16 @@ class Client
      */
     public function upsertWithCounts(string $collection, array $operations, array $options = []): array
     {
+        // MongoDB rejects an `update` command with an empty `updates` array, so
+        // short-circuit dynamically-built batches before they hit the wire.
+        if (empty($operations)) {
+            return [
+                'matched' => 0,
+                'modified' => 0,
+                'upserted' => [],
+            ];
+        }
+
         $updates = [];
 
         foreach ($operations as $op) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -911,6 +911,12 @@ class Client
      * caller can tell exactly which operations produced new docs. Useful for
      * `skipDuplicates`-style callers that need to report "actually inserted" counts.
      *
+     * Counts are only meaningful for acknowledged writes. In practice mongod
+     * still returns `n` for `writeConcern: { w: 0 }` over OP_MSG, so this method
+     * normally works regardless — but if a future protocol change ever causes
+     * `n` to be omitted, the method raises an Exception rather than silently
+     * returning zeros for writes that may have applied.
+     *
      * @param string $collection
      * @param array<int, array{filter: array<string, mixed>, update: array<string, mixed>, multi?: bool}> $operations
      * @param array<string, mixed> $options
@@ -925,7 +931,8 @@ class Client
      *   is the list of newly-created docs, each carrying the source operation's
      *   `index` and the assigned `_id`.
      *
-     * @throws Exception
+     * @throws Exception When the response is missing the `n` field — typically
+     *                   the result of an unacknowledged write concern.
      */
     public function upsertWithCounts(string $collection, array $operations, array $options = []): array
     {
@@ -966,6 +973,19 @@ class Client
             throw new Exception('Unexpected upsertWithCounts response: expected stdClass, got ' . \gettype($result));
         }
 
+        // Defense-in-depth: the counts in this method are only meaningful for
+        // acknowledged writes. In practice mongod always replies with `n` over
+        // OP_MSG (even for writeConcern: { w: 0 }) because send() does not set
+        // the moreToCome flag, so this check is rarely tripped today — but if
+        // a future protocol change ever causes `n` to go missing, refuse loudly
+        // instead of silently returning zeros for writes that may have applied.
+        if (!\property_exists($result, 'n')) {
+            throw new Exception(
+                'upsertWithCounts() requires acknowledged writes — the response did not include `n`. '
+                . 'Do not pass writeConcern: { w: 0 } when calling this method.'
+            );
+        }
+
         $upserted = [];
         if (\property_exists($result, 'upserted') && \is_iterable($result->upserted)) {
             foreach ($result->upserted as $entry) {
@@ -978,8 +998,7 @@ class Client
 
         // MongoDB's `n` in the update response = matched-existing + upserted-new.
         // Subtract the upserts so `matched` reflects only pre-existing docs.
-        $n = (int) ($result->n ?? 0);
-        $matched = \max(0, $n - \count($upserted));
+        $matched = \max(0, (int) $result->n - \count($upserted));
 
         return [
             'matched' => $matched,

--- a/tests/MongoTest.php
+++ b/tests/MongoTest.php
@@ -384,12 +384,45 @@ class MongoTest extends TestCase
 
     public function testUpsertWithCountsEmpty()
     {
-        // Should short-circuit without hitting the wire — MongoDB rejects an
-        // update command with an empty `updates` array.
-        $result = $this->getDatabase()->upsertWithCounts('does_not_matter', []);
+        // The guard should short-circuit before any wire traffic. Indirect proof:
+        // if the guard regressed, this would build an `update` command with an
+        // empty `updates` array, which MongoDB rejects with
+        //   "Failed to parse: updates: array is empty"
+        // — that error would propagate as an Exception and fail this assertion.
+        // We also use a non-existent collection name to ensure the guard runs
+        // before any collection lookup happens.
+        $result = $this->getDatabase()->upsertWithCounts('this_collection_does_not_exist', []);
 
         self::assertSame(['matched' => 0, 'modified' => 0, 'upserted' => []], $result);
     }
+
+    public function testUpsertWithCountsRejectsEmptyUpdatesAtServer()
+    {
+        // Documents the underlying MongoDB behavior the empty-batch guard
+        // relies on. If a future MongoDB version stops rejecting empty
+        // `updates` arrays, the empty-batch test above becomes a weaker check
+        // and we should add a stronger guarantee.
+        $collection = 'upsert_counts_empty_proof';
+        $this->getDatabase()->createCollection($collection);
+        try {
+            $this->expectException(Exception::class);
+
+            // Bypass upsertWithCounts() entirely and send an `update` command
+            // with an empty `updates` array directly through query().
+            $this->getDatabase()->query([
+                'update' => $collection,
+                'updates' => [],
+            ]);
+        } finally {
+            $this->getDatabase()->dropCollection($collection);
+        }
+    }
+
+    // Note: there is no test for the "missing `n` in response" defensive check.
+    // Triggering it would require either a moreToCome OP_MSG flag (not used by
+    // this client) or a stubbed transport — mongod still replies with `n` for
+    // writeConcern: { w: 0 } in normal use, so the check is defense-in-depth
+    // against future protocol changes rather than something callers can hit.
 
     public function testUpsertWithCountsAllExisting()
     {

--- a/tests/MongoTest.php
+++ b/tests/MongoTest.php
@@ -337,9 +337,58 @@ class MongoTest extends TestCase
             $ids = \array_column($result['upserted'], '_id');
             \sort($ids);
             self::assertSame(['a', 'b', 'c'], $ids);
+
+            $indexes = \array_column($result['upserted'], 'index');
+            \sort($indexes);
+            self::assertSame([0, 1, 2], $indexes);
         } finally {
             $this->getDatabase()->dropCollection($collection);
         }
+    }
+
+    public function testUpsertWithCountsModifiesExisting()
+    {
+        $collection = 'upsert_counts_modify';
+        $this->getDatabase()->createCollection($collection);
+        try {
+            $this->getDatabase()->insert($collection, [
+                '_id' => 'exists',
+                'name' => 'Old',
+                'counter' => 1,
+            ]);
+
+            // Use $set (not $setOnInsert) so the matched doc is actually modified.
+            $result = $this->getDatabase()->upsertWithCounts($collection, [
+                [
+                    'filter' => ['_id' => 'exists'],
+                    'update' => [
+                        '$set' => ['name' => 'New'],
+                        '$inc' => ['counter' => 1],
+                    ],
+                ],
+            ]);
+
+            self::assertSame(1, $result['matched']);
+            self::assertSame(1, $result['modified'], 'modified should reflect nModified from MongoDB');
+            self::assertSame([], $result['upserted']);
+
+            // Verify the doc was actually updated on the server.
+            $docs = $this->getDatabase()->find($collection, ['_id' => 'exists'])->cursor->firstBatch ?? [];
+            self::assertCount(1, $docs);
+            self::assertEquals('New', $docs[0]->name);
+            self::assertEquals(2, $docs[0]->counter);
+        } finally {
+            $this->getDatabase()->dropCollection($collection);
+        }
+    }
+
+    public function testUpsertWithCountsEmpty()
+    {
+        // Should short-circuit without hitting the wire — MongoDB rejects an
+        // update command with an empty `updates` array.
+        $result = $this->getDatabase()->upsertWithCounts('does_not_matter', []);
+
+        self::assertSame(['matched' => 0, 'modified' => 0, 'upserted' => []], $result);
     }
 
     public function testUpsertWithCountsAllExisting()

--- a/tests/MongoTest.php
+++ b/tests/MongoTest.php
@@ -271,6 +271,107 @@ class MongoTest extends TestCase
         self::assertEquals('English', $documents[1]->language);
     }
 
+    public function testUpsertWithCountsMixed()
+    {
+        $collection = 'upsert_counts_mixed';
+        $this->getDatabase()->createCollection($collection);
+        try {
+            // Seed one document — it will be matched (no-op) by the first op.
+            $this->getDatabase()->insert($collection, [
+                '_id' => 'existing',
+                'name' => 'Original',
+            ]);
+
+            $result = $this->getDatabase()->upsertWithCounts($collection, [
+                [
+                    'filter' => ['_id' => 'existing'],
+                    // $setOnInsert is a no-op for existing docs — leaves 'Original' intact.
+                    'update' => ['$setOnInsert' => ['name' => 'ShouldNotWrite']],
+                ],
+                [
+                    'filter' => ['_id' => 'fresh'],
+                    'update' => ['$setOnInsert' => ['name' => 'Fresh']],
+                ],
+            ]);
+
+            // One pre-existing match + one upsert = n:2, matched (derived):1, upserted:1.
+            self::assertIsArray($result);
+            self::assertArrayHasKey('matched', $result);
+            self::assertArrayHasKey('modified', $result);
+            self::assertArrayHasKey('upserted', $result);
+
+            self::assertSame(1, $result['matched'], 'matched should exclude upserts');
+            self::assertSame(0, $result['modified']);
+            self::assertCount(1, $result['upserted']);
+            self::assertSame(1, $result['upserted'][0]['index']);
+            self::assertSame('fresh', $result['upserted'][0]['_id']);
+
+            // Existing doc untouched, fresh doc created.
+            $existing = $this->getDatabase()->find($collection, ['_id' => 'existing'])->cursor->firstBatch ?? [];
+            self::assertCount(1, $existing);
+            self::assertEquals('Original', $existing[0]->name);
+
+            $fresh = $this->getDatabase()->find($collection, ['_id' => 'fresh'])->cursor->firstBatch ?? [];
+            self::assertCount(1, $fresh);
+            self::assertEquals('Fresh', $fresh[0]->name);
+        } finally {
+            $this->getDatabase()->dropCollection($collection);
+        }
+    }
+
+    public function testUpsertWithCountsAllNew()
+    {
+        $collection = 'upsert_counts_new';
+        $this->getDatabase()->createCollection($collection);
+        try {
+            $result = $this->getDatabase()->upsertWithCounts($collection, [
+                ['filter' => ['_id' => 'a'], 'update' => ['$setOnInsert' => ['name' => 'A']]],
+                ['filter' => ['_id' => 'b'], 'update' => ['$setOnInsert' => ['name' => 'B']]],
+                ['filter' => ['_id' => 'c'], 'update' => ['$setOnInsert' => ['name' => 'C']]],
+            ]);
+
+            self::assertSame(0, $result['matched'], 'No docs matched — all were upserts');
+            self::assertSame(0, $result['modified']);
+            self::assertCount(3, $result['upserted']);
+
+            $ids = \array_column($result['upserted'], '_id');
+            \sort($ids);
+            self::assertSame(['a', 'b', 'c'], $ids);
+        } finally {
+            $this->getDatabase()->dropCollection($collection);
+        }
+    }
+
+    public function testUpsertWithCountsAllExisting()
+    {
+        $collection = 'upsert_counts_existing';
+        $this->getDatabase()->createCollection($collection);
+        try {
+            $this->getDatabase()->insertMany($collection, [
+                ['_id' => 'a', 'name' => 'A'],
+                ['_id' => 'b', 'name' => 'B'],
+            ]);
+
+            $result = $this->getDatabase()->upsertWithCounts($collection, [
+                ['filter' => ['_id' => 'a'], 'update' => ['$setOnInsert' => ['name' => 'NopeA']]],
+                ['filter' => ['_id' => 'b'], 'update' => ['$setOnInsert' => ['name' => 'NopeB']]],
+            ]);
+
+            self::assertSame(2, $result['matched']);
+            self::assertSame(0, $result['modified']);
+            self::assertSame([], $result['upserted']);
+
+            // Existing values preserved.
+            $docs = $this->getDatabase()->find($collection)->cursor->firstBatch ?? [];
+            self::assertCount(2, $docs);
+            foreach ($docs as $doc) {
+                self::assertContains($doc->name, ['A', 'B']);
+            }
+        } finally {
+            $this->getDatabase()->dropCollection($collection);
+        }
+    }
+
     public function testToArrayWithNestedDocumentFromMongo()
     {
         $client = $this->getDatabase();


### PR DESCRIPTION
## Summary

The existing `Client::upsert()` method returns only MongoDB's raw `n` field — which, per the MongoDB update command, counts matched **plus** upserted documents combined. Callers that need to distinguish "actually newly inserted" from "matched a pre-existing doc" (e.g. for a `skipDuplicates`-style flow in `utopia-php/database`) have no way to do that today.

This PR adds a new method, `upsertWithCounts()`, that exposes the response's `upserted[]` array alongside the counts, so callers can report accurate "new inserts" counts.

## Changes

### `Client.php`

- **New method**: `Client::upsertWithCounts(string $collection, array $operations, array $options = []): array`
  - Returns `{matched: int, modified: int, upserted: array<{index: int, _id: mixed}>}`
  - `matched` is derived as `n - count(upserted)` so it reflects only pre-existing docs, not matched + upserted combined
  - Each upserted entry carries the source operation's `index` (so callers can map back to their input array) and the assigned `_id`
  - **Empty-input guard**: returns `{matched: 0, modified: 0, upserted: []}` immediately for an empty `$operations` array, avoiding the MongoDB-rejects-empty-updates server error
  - **Defense-in-depth**: throws if the response is missing `n`. In practice mongod always replies with `n` over OP_MSG even for `writeConcern: { w: 0 }` because `send()` doesn't set the `moreToCome` flag, so this check is rarely tripped — but it makes the failure mode loud rather than silently returning zeros for writes that may have applied

- **Plumbing**: new optional `bool $returnRaw = false` parameter threaded through `query()` / `send()` / `receive()` / `parseResponse()`. When true, `parseResponse` skips its usual short-circuits and returns the full `stdClass` response. Defaults to `false` — existing callers are unaffected.

- `Client::upsert()` is **unchanged** and still returns `int` (the raw `n` field) for backward compatibility.

### `tests/MongoTest.php`

Six new tests:

- `testUpsertWithCountsMixed` — one pre-existing doc + one new doc. Asserts `matched=1`, `upserted=[{index:1, _id:'fresh'}]`, existing doc's value preserved (via `$setOnInsert` no-op), new doc created.
- `testUpsertWithCountsAllNew` — three new docs, no matches. Asserts `matched=0`, three upserted entries with correct `_id` and `index` values.
- `testUpsertWithCountsAllExisting` — two pre-existing docs, no new inserts. Asserts `matched=2`, empty `upserted`, existing values preserved.
- `testUpsertWithCountsModifiesExisting` — uses `$set + $inc` (not `$setOnInsert`) to actually mutate an existing doc. Asserts `matched=1`, `modified=1`, `upserted=[]`, then verifies the doc's new field values on the server.
- `testUpsertWithCountsEmpty` — empty `$operations` array short-circuits without hitting the wire (uses a non-existent collection name to make the no-wire intent explicit).
- `testUpsertWithCountsRejectsEmptyUpdatesAtServer` — direct `query()` call with an empty `updates` array verifies the underlying MongoDB rejection that the empty-input guard relies on. If a future MongoDB version stops rejecting empty updates we'll catch it here rather than silently weakening the guard.

## Backward compatibility

- `upsert()` signature and return type unchanged.
- Existing response-parsing behavior unchanged when `$returnRaw = false`.
- All existing tests pass.

## Why this matters

Motivating use case: `utopia-php/database` ships a `skipDuplicates` mode on `createDocuments()`. For MongoDB, the adapter uses `upsert() + $setOnInsert` to make concurrent duplicate inserts a silent no-op inside transactions (`insertMany` aborts transactions on duplicate keys; upsert doesn't). Currently the adapter has to maintain a pre-fetch pass to compute the "actually inserted" count because `upsert()` reports matched + upserted combined. With `upsertWithCounts()` the adapter can drop that pre-fetch and rely on the raw response, simplifying its logic by ~15 lines.

## Test plan
- [x] `composer lint` passes
- [x] `composer check` (PHPStan) passes
- [x] `composer test` (PHPUnit against real MongoDB) passes — 30 tests, 129 assertions
- [x] Consumed from `utopia-php/database` Mongo adapter in [PR #852](https://github.com/utopia-php/database/pull/852) and verified the pre-filter is removable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an enhanced upsert operation that returns detailed results: matched count, modified count, and a list of newly upserted entries (with indexes and IDs) for clearer bulk operation feedback.
  * Added an option to request full raw responses for operations when needed.

* **Tests**
  * Added comprehensive tests validating mixed, all-new, modified-existing, empty-update, server-reject, and all-existing upsert scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
