### PR TITLE
feat(client): optional TLS for the MongoDB connection

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -142,7 +142,8 @@ class Client
         int $port,
         string $user,
         string $password,
-        bool $useCoroutine = false
+        bool $useCoroutine = false,
+        bool $tls = false
     ) {
         if (empty($database)) {
             throw new \InvalidArgumentException('Database name cannot be empty');
@@ -177,18 +178,33 @@ class Client
             }
         }
 
+        $flags = SWOOLE_SOCK_TCP | SWOOLE_KEEP;
+        if ($tls) {
+            $flags |= SWOOLE_SSL;
+        }
+
         $this->client = $useCoroutine
-            ? new CoroutineClient(SWOOLE_SOCK_TCP | SWOOLE_KEEP)
-            : new SwooleClient(SWOOLE_SOCK_TCP | SWOOLE_KEEP);
+            ? new CoroutineClient($flags)
+            : new SwooleClient($flags);
 
         // Set socket options to prevent hanging
-        $this->client->set([
+        $options = [
             'open_tcp_keepalive' => true,
             'tcp_keepidle' => 4,     // Start keepalive after 4s idle
             'tcp_keepinterval' => 3, // Keepalive interval 3s
             'tcp_keepcount' => 2,    // Close after 2 failed keepalives
             'timeout' => 30          // 30 second connection timeout
-        ]);
+        ];
+
+        if ($tls) {
+            // The backend is reached through a TLS-terminating proxy presenting a
+            // trusted platform certificate; encrypt the hop without enforcing peer
+            // verification (the proxy hostname is not on the backend's own cert).
+            $options['ssl_verify_peer'] = false;
+            $options['ssl_allow_self_signed'] = true;
+        }
+
+        $this->client->set($options);
 
         $this->auth = new Auth([
             'authcid' => $user,

--- a/src/Client.php
+++ b/src/Client.php
@@ -143,7 +143,8 @@ class Client
         string $user,
         string $password,
         bool $useCoroutine = false,
-        bool $tls = false
+        bool $tls = false,
+        array $tlsOptions = []
     ) {
         if (empty($database)) {
             throw new \InvalidArgumentException('Database name cannot be empty');
@@ -197,11 +198,12 @@ class Client
         ];
 
         if ($tls) {
-            // The backend is reached through a TLS-terminating proxy presenting a
-            // trusted platform certificate; encrypt the hop without enforcing peer
-            // verification (the proxy hostname is not on the backend's own cert).
-            $options['ssl_verify_peer'] = false;
-            $options['ssl_allow_self_signed'] = true;
+            // TLS is the mechanism; the caller owns the verification policy. Pass
+            // ssl_verify_peer / ssl_cafile / ssl_host_name (etc.) via $tlsOptions —
+            // e.g. verify against the system CA in production, or relax verification
+            // where the endpoint presents an untrusted certificate. Defaults to
+            // Swoole's behaviour when no options are given.
+            $options = array_merge($options, $tlsOptions);
         }
 
         $this->client->set($options);


### PR DESCRIPTION
## Summary
Adds optional TLS to the Mongo `Client`: a `bool $tls = false` flag opens the Swoole socket with `SWOOLE_SSL`, and a `array $tlsOptions = []` lets the caller set the verification policy (`ssl_verify_peer`, `ssl_cafile`, `ssl_host_name`, `ssl_allow_self_signed`, …). Defaults off — self-hosted plaintext connections are unaffected.

## Why
Appwrite Cloud's dedicated MongoDB backends (documentsdb) are reached through the edge TCP proxy, which **requires** TLS. The driver had no TLS support. The driver intentionally does **not** hardcode a verification policy — the consumer verifies against the system CA in production, and may relax verification only where the endpoint presents an untrusted cert (e.g. staging uses a Let's Encrypt *staging* certificate that isn't publicly trusted).

## Notes
- BC: `$tls` defaults false; existing 6-arg callers unchanged.
- E2E verification: exercised by Cloud's documentsdb path through the edge proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional TLS/SSL encryption for client connections, enableable via configuration while preserving existing behavior by default.
  * Support for providing TLS options (verification and related settings) so callers can control certificate/peer verification and other TLS policies.
  * Socket-level TLS is now applied when enabled, improving transport security for deployments that require encryption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->