### PR TITLE
feat(client): support custom authSource for SCRAM authentication

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -9,6 +9,7 @@ class Auth
     private string $authcid;
     private string $secret;
     private string $authzid;
+    private string $authSource;
     private string $gs2Header;
     private ?string $cnonce = null;
     private string $firstMessageBare;
@@ -23,6 +24,7 @@ class Auth
         $this->authcid = $options['authcid'] ?? '';
         $this->secret = $options['secret'] ?? '';
         $this->authzid = $options['authzid'] ?? '';
+        $this->authSource = $options['authSource'] ?? 'admin';
         $this->cnonce = base64_encode(random_bytes(32));
     }
 
@@ -39,7 +41,7 @@ class Auth
                 "autoAuthorize" => 1,
                 "options" => ["skipEmptyExchange" => true],
             ],
-            'admin'
+            $this->authSource
         ];
     }
 
@@ -61,7 +63,7 @@ class Auth
                 "conversationId" => $cid,
                 "payload" => $payload,
             ],
-            'admin'
+            $this->authSource
         ];
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -134,6 +134,9 @@ class Client
      * @param string $user
      * @param string $password
      * @param Boolean $useCoroutine
+     * @param string|null $authSource Database to authenticate against; defaults to 'admin'.
+     *     Set this when the user was created in a database other than admin (e.g. the
+     *     application database itself).
      * @throws \Exception
      */
     public function __construct(
@@ -144,7 +147,8 @@ class Client
         string $password,
         bool $useCoroutine = false,
         bool $tls = false,
-        array $tlsOptions = []
+        array $tlsOptions = [],
+        ?string $authSource = null
     ) {
         if (empty($database)) {
             throw new \InvalidArgumentException('Database name cannot be empty');
@@ -210,7 +214,8 @@ class Client
 
         $this->auth = new Auth([
             'authcid' => $user,
-            'secret' => Auth::encodeCredentials($user, $password)
+            'secret' => Auth::encodeCredentials($user, $password),
+            'authSource' => $authSource ?? 'admin',
         ]);
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -134,6 +134,8 @@ class Client
      * @param string $user
      * @param string $password
      * @param Boolean $useCoroutine
+     * @param bool $tls
+     * @param array $tlsOptions
      * @param string|null $authSource Database to authenticate against; defaults to 'admin'.
      *     Set this when the user was created in a database other than admin (e.g. the
      *     application database itself).

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Utopia\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Mongo\Auth;
+
+class AuthTest extends TestCase
+{
+    public function testStartDefaultsToAdminAuthSource(): void
+    {
+        $auth = new Auth([
+            'authcid' => 'root',
+            'secret' => Auth::encodeCredentials('root', 'example'),
+        ]);
+
+        [$payload, $database] = $auth->start();
+
+        $this->assertSame(1, $payload['saslStart']);
+        $this->assertSame('admin', $database);
+    }
+
+    public function testStartUsesProvidedAuthSource(): void
+    {
+        $auth = new Auth([
+            'authcid' => 'appuser',
+            'secret' => Auth::encodeCredentials('appuser', 'example'),
+            'authSource' => 'appdb',
+        ]);
+
+        [$payload, $database] = $auth->start();
+
+        $this->assertSame(1, $payload['saslStart']);
+        $this->assertSame('appdb', $database);
+    }
+
+    public function testContinueUsesProvidedAuthSource(): void
+    {
+        $auth = new Auth([
+            'authcid' => 'appuser',
+            'secret' => Auth::encodeCredentials('appuser', 'example'),
+            'authSource' => 'appdb',
+        ]);
+
+        $auth->start();
+
+        $data = new \stdClass();
+        $data->conversationId = 1;
+        $data->payload = new \MongoDB\BSON\Binary('r=' . $auth->getCnonce() . 'server,s=' . base64_encode('salt') . ',i=4096', 0);
+
+        [$payload, $database] = $auth->continue($data);
+
+        $this->assertSame(1, $payload['saslContinue']);
+        $this->assertSame('appdb', $database);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

SCRAM authentication (`saslStart`/`saslContinue`) was hardcoded to run against the `admin` database. That fails for deployments where the user is created **in the application database itself** (`db.createUser()` executed inside the target database) — a common pattern for per-database app users.

- `Auth` accepts an `authSource` option (defaults to `admin`) and runs both SCRAM steps against it.
- `Client` gains a trailing, optional `authSource` constructor parameter, passed through to `Auth`.

Fully backward compatible: omitted/null `authSource` behaves exactly as before.

## Test plan

- `tests/AuthTest.php`: asserts the default is `admin` and that a provided `authSource` is used for both `start()` and `continue()`.
- Verified live against `mongo:8`: a user created inside `appdb` fails SCRAM with the default (admin) and connects + writes successfully with `authSource: 'appdb'`.
- Full suite: 28 tests / 104 assertions green; Pint and PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom MongoDB authentication source (defaults to `admin` when not provided).
  * Connection/login now uses the specified authentication source consistently, including during authentication continuation.

* **Tests**
  * Added PHPUnit coverage verifying the default authentication source behavior.
  * Added PHPUnit coverage verifying custom authentication source handling across both initial login and continuation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->