### PR TITLE
fix: fail fast on Mongo socket receive timeouts

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -44,6 +44,15 @@ class Client
     private bool $isConnected = false;
 
     /**
+     * Socket / receive timeout in seconds.
+     *
+     * Applied to the Swoole client `timeout` option and used as a wall-clock
+     * deadline in receive(). recv() returning false already means this wait
+     * elapsed — receive() must not multiply it with thousands of retries.
+     */
+    private float $receiveTimeout = 30.0;
+
+    /**
      * Defines commands Mongo uses over wire protocol.
      */
 
@@ -200,7 +209,7 @@ class Client
             'tcp_keepidle' => 4,     // Start keepalive after 4s idle
             'tcp_keepinterval' => 3, // Keepalive interval 3s
             'tcp_keepcount' => 2,    // Close after 2 failed keepalives
-            'timeout' => 30          // 30 second connection timeout
+            'timeout' => $this->receiveTimeout,
         ];
 
         if ($tls) {
@@ -417,11 +426,16 @@ class Client
 
         // If send fails, try to reconnect once
         if ($result === false) {
+            $errCode = $this->client->errCode ?? 0;
             $this->close();
             $this->connect();
             $result = $this->client->send($data);
             if ($result === false) {
-                throw new Exception('Failed to send data to MongoDB after reconnection attempt');
+                $errCode = $this->client->errCode ?? $errCode;
+                throw new Exception(
+                    'Failed to send data to MongoDB after reconnection attempt'
+                    . ($errCode !== 0 ? " (errCode={$errCode})" : '')
+                );
             }
         }
 
@@ -430,6 +444,13 @@ class Client
 
     /**
      * Receive a message from connection.
+     *
+     * Swoole's socket `timeout` already bounds a single recv(). Treating false
+     * (or a timed-out empty read) as "try again" up to 10k times multiplies
+     * that into multi-minute hangs (observed as Appwrite create requests
+     * returning 0 bytes until the HTTP client's 120s curl timeout fires under
+     * Mongo load).
+     *
      * @throws Exception
      */
     private function receive(): stdClass|array|int
@@ -437,32 +458,43 @@ class Client
         $chunks = [];
         $receivedLength = 0;
         $responseLength = null;
-        $attempts = 0;
-        $maxAttempts = 10000;
-        $sleepTime = 100;
+        $deadline = \microtime(true) + $this->receiveTimeout;
 
         do {
+            if (\microtime(true) >= $deadline) {
+                throw new Exception('Receive timeout: no data received within reasonable time');
+            }
+
             $chunk = @$this->client->recv();
+            $errCode = $this->client->errCode ?? 0;
 
-            if ($chunk === false || $chunk === '') {
-                $attempts++;
-                if ($attempts >= $maxAttempts) {
-                    throw new Exception('Receive timeout: no data received within reasonable time');
-                }
+            // false => socket-level wait already elapsed with no payload.
+            // Do not retry: that turns one timeout into thousands.
+            if ($chunk === false) {
+                throw new Exception(
+                    'Receive timeout: no data received within reasonable time'
+                    . ($errCode !== 0 ? " (errCode={$errCode})" : '')
+                );
+            }
 
-                // Adaptive backoff: shorter delays for coroutines, longer for sync
+            // Some Swoole builds return "" on recv timeout instead of false.
+            // errCode != 0 distinguishes that from a transient empty read.
+            if ($chunk === '' && $errCode !== 0) {
+                throw new Exception(
+                    'Receive timeout: no data received within reasonable time'
+                    . " (errCode={$errCode})"
+                );
+            }
+
+            // Transient empty read with no error; yield until deadline.
+            if ($chunk === '') {
                 if ($this->client instanceof CoroutineClient) {
-                    Coroutine::sleep(0.001); // 1ms for coroutines
+                    Coroutine::sleep(0.001);
                 } else {
-                    \usleep((int)$sleepTime); // Microsecond precision for sync client
-                    $sleepTime = (int)\min($sleepTime * 1.2, 10000); // Cap at 10ms for faster checking
+                    \usleep(1000);
                 }
                 continue;
             }
-
-            // Reset attempts counter when we receive data
-            $attempts = 0;
-            $sleepTime = 100; // Reset to 0.1ms
 
             $chunkLen = \strlen($chunk);
             $receivedLength += $chunkLen;

--- a/src/Client.php
+++ b/src/Client.php
@@ -150,6 +150,7 @@ class Client
      * @param string|null $authSource Database to authenticate against; defaults to 'admin'.
      *     Set this when the user was created in a database other than admin (e.g. the
      *     application database itself).
+     * @param float $timeout Socket / receive idle timeout in seconds (default 30).
      * @throws \Exception
      */
     public function __construct(
@@ -161,7 +162,8 @@ class Client
         bool $useCoroutine = false,
         bool $tls = false,
         array $tlsOptions = [],
-        ?string $authSource = null
+        ?string $authSource = null,
+        float $timeout = 30.0
     ) {
         if (empty($database)) {
             throw new \InvalidArgumentException('Database name cannot be empty');
@@ -178,11 +180,15 @@ class Client
         if (empty($password)) {
             throw new \InvalidArgumentException('Password cannot be empty');
         }
+        if ($timeout <= 0) {
+            throw new \InvalidArgumentException('Timeout must be greater than 0');
+        }
 
         $this->id = uniqid('utopia.mongo.client');
         $this->database = $database;
         $this->host = $host;
         $this->port = $port;
+        $this->receiveTimeout = $timeout;
 
         // Only use coroutines if explicitly requested and we're in a coroutine context
         if ($useCoroutine) {
@@ -230,32 +236,6 @@ class Client
             'secret' => Auth::encodeCredentials($user, $password),
             'authSource' => $authSource ?? 'admin',
         ]);
-    }
-
-    /**
-     * Set the socket / receive idle timeout in seconds.
-     *
-     * Updates both the Swoole client `timeout` option and the idle deadline
-     * used by receive(). Must be > 0.
-     */
-    public function setTimeout(float $seconds): self
-    {
-        if ($seconds <= 0) {
-            throw new \InvalidArgumentException('Timeout must be greater than 0');
-        }
-
-        $this->receiveTimeout = $seconds;
-        $this->client->set(['timeout' => $this->receiveTimeout]);
-
-        return $this;
-    }
-
-    /**
-     * Get the socket / receive idle timeout in seconds.
-     */
-    public function getTimeout(): float
-    {
-        return $this->receiveTimeout;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -52,7 +52,7 @@ class Client
      * The deadline resets whenever a real chunk arrives so large responses
      * can still complete under load.
      */
-    private float $receiveTimeout = 30.0;
+    private float $timeout = 30.0;
 
     /**
      * Defines commands Mongo uses over wire protocol.
@@ -188,7 +188,7 @@ class Client
         $this->database = $database;
         $this->host = $host;
         $this->port = $port;
-        $this->receiveTimeout = $timeout;
+        $this->timeout = $timeout;
 
         // Only use coroutines if explicitly requested and we're in a coroutine context
         if ($useCoroutine) {
@@ -217,7 +217,7 @@ class Client
             'tcp_keepidle' => 4,     // Start keepalive after 4s idle
             'tcp_keepinterval' => 3, // Keepalive interval 3s
             'tcp_keepcount' => 2,    // Close after 2 failed keepalives
-            'timeout' => $this->receiveTimeout,
+            'timeout' => $this->timeout,
         ];
 
         if ($tls) {
@@ -463,7 +463,7 @@ class Client
      *
      * The idle deadline resets whenever a real chunk arrives so large
      * responses can finish under load; we only fail when the socket goes
-     * silent for `$receiveTimeout` seconds.
+     * silent for `$timeout` seconds.
      *
      * @throws Exception
      */
@@ -472,7 +472,7 @@ class Client
         $chunks = [];
         $receivedLength = 0;
         $responseLength = null;
-        $deadline = \microtime(true) + $this->receiveTimeout;
+        $deadline = \microtime(true) + $this->timeout;
 
         do {
             if (\microtime(true) >= $deadline) {
@@ -514,7 +514,7 @@ class Client
 
             // Activity: extend idle deadline so large multi-chunk responses
             // are not cut off by a fixed wall-clock budget from the first byte.
-            $deadline = \microtime(true) + $this->receiveTimeout;
+            $deadline = \microtime(true) + $this->timeout;
 
             $chunkLen = \strlen($chunk);
             $receivedLength += $chunkLen;

--- a/src/Client.php
+++ b/src/Client.php
@@ -44,11 +44,13 @@ class Client
     private bool $isConnected = false;
 
     /**
-     * Socket / receive timeout in seconds.
+     * Socket / receive idle timeout in seconds.
      *
-     * Applied to the Swoole client `timeout` option and used as a wall-clock
+     * Applied to the Swoole client `timeout` option and used as an idle
      * deadline in receive(). recv() returning false already means this wait
      * elapsed — receive() must not multiply it with thousands of retries.
+     * The deadline resets whenever a real chunk arrives so large responses
+     * can still complete under load.
      */
     private float $receiveTimeout = 30.0;
 
@@ -228,6 +230,32 @@ class Client
             'secret' => Auth::encodeCredentials($user, $password),
             'authSource' => $authSource ?? 'admin',
         ]);
+    }
+
+    /**
+     * Set the socket / receive idle timeout in seconds.
+     *
+     * Updates both the Swoole client `timeout` option and the idle deadline
+     * used by receive(). Must be > 0.
+     */
+    public function setTimeout(float $seconds): self
+    {
+        if ($seconds <= 0) {
+            throw new \InvalidArgumentException('Timeout must be greater than 0');
+        }
+
+        $this->receiveTimeout = $seconds;
+        $this->client->set(['timeout' => $this->receiveTimeout]);
+
+        return $this;
+    }
+
+    /**
+     * Get the socket / receive idle timeout in seconds.
+     */
+    public function getTimeout(): float
+    {
+        return $this->receiveTimeout;
     }
 
     /**
@@ -431,10 +459,12 @@ class Client
             $this->connect();
             $result = $this->client->send($data);
             if ($result === false) {
-                $errCode = $this->client->errCode ?? $errCode;
+                // Prefer the first non-zero errCode (retry may report 0).
+                $errCode = ($this->client->errCode ?? 0) ?: $errCode;
                 throw new Exception(
                     'Failed to send data to MongoDB after reconnection attempt'
-                    . ($errCode !== 0 ? " (errCode={$errCode})" : '')
+                    . ($errCode !== 0 ? " (errCode={$errCode})" : ''),
+                    $errCode !== 0 ? $errCode : 9001 // SocketException
                 );
             }
         }
@@ -451,6 +481,10 @@ class Client
      * returning 0 bytes until the HTTP client's 120s curl timeout fires under
      * Mongo load).
      *
+     * The idle deadline resets whenever a real chunk arrives so large
+     * responses can finish under load; we only fail when the socket goes
+     * silent for `$receiveTimeout` seconds.
+     *
      * @throws Exception
      */
     private function receive(): stdClass|array|int
@@ -462,7 +496,7 @@ class Client
 
         do {
             if (\microtime(true) >= $deadline) {
-                throw new Exception('Receive timeout: no data received within reasonable time');
+                throw new Exception('Receive timeout: no data received within reasonable time', 11601);
             }
 
             $chunk = @$this->client->recv();
@@ -473,7 +507,8 @@ class Client
             if ($chunk === false) {
                 throw new Exception(
                     'Receive timeout: no data received within reasonable time'
-                    . ($errCode !== 0 ? " (errCode={$errCode})" : '')
+                    . ($errCode !== 0 ? " (errCode={$errCode})" : ''),
+                    11601 // SocketTimeout
                 );
             }
 
@@ -482,11 +517,12 @@ class Client
             if ($chunk === '' && $errCode !== 0) {
                 throw new Exception(
                     'Receive timeout: no data received within reasonable time'
-                    . " (errCode={$errCode})"
+                    . " (errCode={$errCode})",
+                    11601 // SocketTimeout
                 );
             }
 
-            // Transient empty read with no error; yield until deadline.
+            // Transient empty read with no error; yield until idle deadline.
             if ($chunk === '') {
                 if ($this->client instanceof CoroutineClient) {
                     Coroutine::sleep(0.001);
@@ -495,6 +531,10 @@ class Client
                 }
                 continue;
             }
+
+            // Activity: extend idle deadline so large multi-chunk responses
+            // are not cut off by a fixed wall-clock budget from the first byte.
+            $deadline = \microtime(true) + $this->receiveTimeout;
 
             $chunkLen = \strlen($chunk);
             $receivedLength += $chunkLen;


### PR DESCRIPTION
## What does this PR do?

Fails fast when a Swoole Mongo socket `recv()` times out, instead of retrying up to **10 000** times and turning a single ~30s socket timeout into a multi-minute hang.

This was found while investigating Appwrite CI flake `DocumentsDBCustomServerTest::testTimeout` (create of ~12MB documents under load). Appwrite never got an HTTP response; the e2e client hit:

```text
Exception: Operation timed out after 12000x milliseconds with 0 bytes received
```

Appwrite logs during the hang showed the library spinning / then failing late:

```text
Utopia\Mongo\Exception: Receive timeout: no data received within reasonable time
Swoole\Client::send(): ... Broken pipe
```

### Root cause

`Client::receive()` treated `recv() === false` (and empty string) as “try again” with adaptive sleep, up to `maxAttempts = 10000`. The Swoole client already has `'timeout' => 30`, so each failed `recv()` can wait ~30s. Retrying that path multiplies into hangs that exceed Appwrite’s HTTP client **120s** curl timeout — the API never responds.

Relevant **before** behavior:

```php
$attempts = 0;
$maxAttempts = 10000;
$sleepTime = 100;

do {
    $chunk = @$this->client->recv();

    if ($chunk === false || $chunk === '') {
        $attempts++;
        if ($attempts >= $maxAttempts) {
            throw new Exception('Receive timeout: no data received within reasonable time');
        }
        // sleep / backoff, continue...
    }

    // any partial byte reset $attempts = 0
} while (true);
```

### Fix

1. **`recv() === false` → throw immediately** (socket wait already elapsed; do not multiply it).
2. **Wall-clock deadline** = `$receiveTimeout` (30s), shared with the Swoole `'timeout'` option.
3. **`''` + nonzero `errCode`** → treat as timeout (some Swoole builds return empty string on timeout instead of `false`).
4. Transient empty reads with `errCode === 0` still yield briefly until the deadline.
5. Clearer **send** errors include `errCode` after reconnection failure.

Relevant **after** behavior:

```php
$deadline = \microtime(true) + $this->receiveTimeout;

do {
    if (\microtime(true) >= $deadline) {
        throw new Exception('Receive timeout: no data received within reasonable time');
    }

    $chunk = @$this->client->recv();
    $errCode = $this->client->errCode ?? 0;

    if ($chunk === false) {
        throw new Exception(
            'Receive timeout: no data received within reasonable time'
            . ($errCode !== 0 ? " (errCode={$errCode})" : '')
        );
    }

    if ($chunk === '' && $errCode !== 0) {
        throw new Exception(
            'Receive timeout: no data received within reasonable time'
            . " (errCode={$errCode})"
        );
    }

    if ($chunk === '') {
        // brief yield until deadline
        continue;
    }
    // ... assemble response ...
} while (true);
```

Under load, Appwrite now surfaces fail-fast errors like:

```text
Receive timeout: no data received within reasonable time (errCode=11)
```

instead of silently blocking until the HTTP client gives up.

## How we reproduced (Appwrite + this driver)

Local OrbStack stack, CPU-capped to force Mongo contention:

```bash
docker update --cpus=0.5 appwrite
docker update --cpus=0.5 appwrite-mongodb

# 3 concurrent DocumentsDBCustomServerTest::testTimeout loops × 5 iters
# (each creates 10 × ~12MB documents, then asserts query timeout → 408)
```

### Stress results

| Run | OK | Client 120s hang (`0 bytes received`) | Other |
|-----|----|----------------------------------------|-------|
| **Unpatched** | 3 | 3+ (then cascade) | broken pipes / account 500s |
| **Patch v1** (`recv false` fail-fast only) | 11 | 4 | — |
| **Patch v2** (this PR: + empty/`errCode` + send errCode) | 9 | 2 | 3× invalid JSON, 1× `500 ≠ 408` |

**What this fixes:** the library no longer multiplies one socket timeout into a multi-minute receive loop. Failures show up as Mongo `Receive timeout (errCode=11)` within ~one socket timeout budget.

**What this does not fully eliminate:** under extreme 0.5 CPU + concurrent 12MB creates, some requests can still starve past curl’s 120s (worker/CPU starvation) or return truncated bodies. That class of flake still wants a lighter Appwrite `testTimeout` setup and/or mapping Mongo receive timeouts → HTTP **408** on the Appwrite side (`DATABASE_TIMEOUT`).

Alone / unloaded, `testTimeout` completes in ~10–14s.

## Test plan

- [ ] CI: existing `utopia-php/mongo` unit/integration suite
- [x] Local Appwrite stress (above) with patched vendor `Client.php` copied into running container
- [x] Confirmed fail-fast log line `Receive timeout ... (errCode=11)` after patch
- [ ] Optional follow-ups (separate repos):
  - Appwrite: map Mongo receive timeout → `DATABASE_TIMEOUT` (408)
  - Appwrite: lighten `DatabasesBase::testTimeout` document payload / count

## Notes / BC

- Default timeout remains **30s** (same as previous hardcoded Swoole `timeout`).
- Behavior change: callers that previously hung for minutes on a dead/slow socket will now get an exception roughly within one receive timeout. That is intentional.
- Inserts/writes still do not pass `maxTimeMS` via the database adapter; this PR only fixes the wire-protocol receive loop, not query `maxTimeMS` semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection receive timeout handling with a consistent, configurable deadline.
  * Prevented empty, non-error socket reads from causing premature failures.
  * Enhanced error reporting when sending fails after a reconnection attempt.
  * Ensured receive operations fail promptly on socket errors and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->