### PR TITLE
Fix Mongo transport recovery after socket failures

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -436,8 +436,21 @@ class Client
         // A partial write corrupts the request boundary just like a failed write.
         if ($result !== $length) {
             $errCode = $this->client->errCode ?? 0;
+            $sessions = $this->sessions;
             $this->invalidate();
-            $this->connect();
+
+            try {
+                $this->connect();
+            } catch (\Throwable $error) {
+                if ($this->isConnected || $this->client->isConnected()) {
+                    $this->invalidate();
+                }
+
+                throw $error;
+            }
+
+            // Logical sessions survive only after a fresh socket authenticates.
+            $this->sessions = $sessions;
             $result = $this->client->send($data);
 
             if ($result !== $length) {
@@ -1746,6 +1759,8 @@ class Client
             throw new Exception('Response length mismatch');
         }
 
+        // query() emits OP_MSG and this parser decodes its 21-byte envelope.
+        // OP_REPLY uses an incompatible 36-byte envelope and is not supported.
         if ($headerData['opCode'] !== 2013) {
             $this->invalidate();
             throw new Exception('Invalid response operation code: ' . $headerData['opCode']);

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,7 +4,6 @@ namespace Utopia\Mongo;
 
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
-use MongoDB\Driver\Exception\InvalidArgumentException;
 use Ramsey\Uuid\Uuid;
 use stdClass;
 use Swoole\Client as SwooleClient;
@@ -253,7 +252,8 @@ class Client
         if ($this->port <= 0 || $this->port > 65535) {
             throw new Exception('MongoDB port must be between 1 and 65535');
         }
-        if (!$this->client->connect($this->host, $this->port)) {
+        if (!$this->client->connect($this->host, $this->port, $this->timeout)) {
+            $this->invalidate();
             throw new Exception("Failed to connect to MongoDB at {$this->host}:{$this->port}");
         }
 
@@ -430,17 +430,20 @@ class Client
             $this->connect();
         }
 
+        $length = \strlen($data);
         $result = $this->client->send($data);
 
-        // If send fails, try to reconnect once
-        if ($result === false) {
+        // A partial write corrupts the request boundary just like a failed write.
+        if ($result !== $length) {
             $errCode = $this->client->errCode ?? 0;
-            $this->close();
+            $this->invalidate();
             $this->connect();
             $result = $this->client->send($data);
-            if ($result === false) {
+
+            if ($result !== $length) {
                 // Prefer the first non-zero errCode (retry may report 0).
                 $errCode = ($this->client->errCode ?? 0) ?: $errCode;
+                $this->invalidate();
                 throw new Exception(
                     'Failed to send data to MongoDB after reconnection attempt'
                     . ($errCode !== 0 ? " (errCode={$errCode})" : ''),
@@ -476,6 +479,7 @@ class Client
 
         do {
             if (\microtime(true) >= $deadline) {
+                $this->invalidate();
                 throw new Exception('Receive timeout: no data received within reasonable time', 11601);
             }
 
@@ -485,6 +489,7 @@ class Client
             // false => socket-level wait already elapsed with no payload.
             // Do not retry: that turns one timeout into thousands.
             if ($chunk === false) {
+                $this->invalidate();
                 throw new Exception(
                     'Receive timeout: no data received within reasonable time'
                     . ($errCode !== 0 ? " (errCode={$errCode})" : ''),
@@ -495,6 +500,7 @@ class Client
             // Some Swoole builds return "" on recv timeout instead of false.
             // errCode != 0 distinguishes that from a transient empty read.
             if ($chunk === '' && $errCode !== 0) {
+                $this->invalidate();
                 throw new Exception(
                     'Receive timeout: no data received within reasonable time'
                     . " (errCode={$errCode})",
@@ -532,16 +538,23 @@ class Client
 
                 // Validate response length before allocating memory to prevent memory exhaustion
                 if ($responseLength > 16777216) { // 16MB limit
+                    $this->invalidate();
                     throw new Exception('Response too large: ' . $responseLength . ' bytes');
                 }
 
                 // Validate for negative or tiny values
                 if ($responseLength < 21) { // Minimum MongoDB message size
+                    $this->invalidate();
                     throw new Exception('Invalid response length: ' . $responseLength . ' bytes');
                 }
             }
 
-            if ($responseLength !== null && $receivedLength >= $responseLength) {
+            if ($responseLength !== null && $receivedLength > $responseLength) {
+                $this->invalidate();
+                throw new Exception('Response length mismatch');
+            }
+
+            if ($responseLength !== null && $receivedLength === $responseLength) {
                 break;
             }
         } while (true);
@@ -1657,10 +1670,37 @@ class Client
             $this->client->close();
         }
 
+        $this->reset();
+    }
+
+    /**
+     * Physically close a failed socket without writing session cleanup to it.
+     */
+    private function invalidate(): void
+    {
+        try {
+            if ($this->client instanceof CoroutineClient) {
+                @$this->client->close();
+            } else {
+                @$this->client->close(true);
+            }
+        } catch (\Throwable) {
+            // The transport may already be closed or only partially initialized.
+        } finally {
+            $this->reset();
+        }
+    }
+
+    /**
+     * Clear all state associated with the current physical connection.
+     */
+    private function reset(): void
+    {
         $this->isConnected = false;
         $this->sessions = [];
         $this->clusterTime = null;
         $this->operationTime = null;
+        $this->replicaSet = null;
     }
 
     /**
@@ -1686,7 +1726,13 @@ class Client
          * These 21 bytes are protocol metadata and precede the actual BSON-encoded document in the response.
          */
 
-        if (\strlen($response) < 21) {
+        if (\strlen($response) !== $responseLength) {
+            $this->invalidate();
+            throw new Exception('Response length mismatch');
+        }
+
+        if ($responseLength < 21) {
+            $this->invalidate();
             throw new Exception('Invalid response: too short');
         }
 
@@ -1695,19 +1741,30 @@ class Client
         $headerData = \unpack('VmessageLength/VrequestID/VresponseTo/VopCode', $header);
 
         // Validate message length
-        if ($headerData['messageLength'] !== $responseLength) {
+        if ($headerData === false || $headerData['messageLength'] !== $responseLength) {
+            $this->invalidate();
             throw new Exception('Response length mismatch');
         }
 
-        // Extract flag bits and payload type
-        $flagBits = \unpack('V', \substr($response, 16, 4))[1];
+        if ($headerData['opCode'] !== 2013) {
+            $this->invalidate();
+            throw new Exception('Invalid response operation code: ' . $headerData['opCode']);
+        }
+
+        // Extract payload type after the flag bits.
         $payloadType = \ord(\substr($response, 20, 1));
+
+        if ($payloadType !== 0) {
+            $this->invalidate();
+            throw new Exception('Invalid response payload type: ' . $payloadType);
+        }
 
         // Extract BSON document (skip header + flagBits + payloadType)
         $bsonString = \substr($response, 21, $responseLength - 21);
 
         if (empty($bsonString)) {
-            return new \stdClass();
+            $this->invalidate();
+            throw new Exception('Invalid response: missing BSON document');
         }
 
         try {
@@ -1718,45 +1775,45 @@ class Client
             if (\is_array($result)) {
                 $result = (object)$result;
             }
+        } catch (\Throwable $error) {
+            $this->invalidate();
+            throw new Exception('Failed to parse BSON response: ' . $error->getMessage(), 0, $error);
+        }
 
-            // Check for write errors (duplicate key, etc.)
-            if (\property_exists($result, 'writeErrors') && !empty($result->writeErrors)) {
-                throw new Exception(
-                    $result->writeErrors[0]->errmsg,
-                    $result->writeErrors[0]->code
-                );
+        // These are fully decoded MongoDB command errors, not transport corruption.
+        if (\property_exists($result, 'writeErrors') && !empty($result->writeErrors)) {
+            $writeError = $result->writeErrors[0] ?? null;
+
+            if (\is_object($writeError) && isset($writeError->errmsg, $writeError->code)) {
+                throw new Exception($writeError->errmsg, $writeError->code);
             }
 
-            // Check for general MongoDB errors
-            if (\property_exists($result, 'errmsg')) {
-                throw new Exception(
-                    'E' . $result->code . ' ' . $result->codeName . ': ' . $result->errmsg,
-                    $result->code
-                );
-            }
+            $this->invalidate();
+            throw new Exception('Invalid write error response');
+        }
 
-            // Check for operation success
-            if (\property_exists($result, 'n') && $result->ok === 1.0) {
+        if (\property_exists($result, 'errmsg')) {
+            $code = (int)($result->code ?? 0);
+            $name = (string)($result->codeName ?? 'MongoError');
+
+            throw new Exception('E' . $code . ' ' . $name . ': ' . $result->errmsg, $code);
+        }
+
+        if (!\property_exists($result, 'ok')) {
+            $this->invalidate();
+            throw new Exception('Invalid response: missing operation status');
+        }
+
+        if ($result->ok === 1.0) {
+            if (\property_exists($result, 'n')) {
                 return $result->n;
             }
 
-            if (\property_exists($result, 'nonce') && $result->ok === 1.0) {
-                return $result;
-            }
-
-            if ($result->ok === 1.0) {
-                return $result;
-            }
-
-            return $result->cursor->firstBatch;
-        } catch (InvalidArgumentException $e) {
-            throw new Exception('Failed to parse BSON response: ' . $e->getMessage());
-        } catch (\Exception $e) {
-            if ($e instanceof Exception) {
-                throw $e;
-            }
-            throw new Exception('Error parsing response: ' . $e->getMessage());
+            return $result;
         }
+
+        $this->invalidate();
+        throw new Exception('Invalid unsuccessful response');
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Utopia\Tests;
 
+use MongoDB\BSON\Binary;
 use MongoDB\BSON\Document;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -15,6 +16,7 @@ use Utopia\Mongo\Exception;
 trait TransportDouble
 {
     public bool $open = true;
+    public array $connectionResults = [];
     public array $connects = [];
     public array $events = [];
     public array $receives = [];
@@ -25,9 +27,10 @@ trait TransportDouble
     {
         $this->events[] = ['connect', $host, $port, $timeout, $flags];
         $this->connects[] = [$host, $port, $timeout, $flags];
-        $this->open = true;
+        $result = array_shift($this->connectionResults) ?? true;
+        $this->open = $result;
 
-        return true;
+        return $result;
     }
 
     private function receiveTransport(): string|false
@@ -270,8 +273,42 @@ final class ClientTest extends TestCase
             array_column($transport->events, 0)
         );
         $this->assertSame([[true]], $transport->closes);
-        $this->assertContextCleared($client);
+        $sessions = $this->get($client, 'sessions');
+        $this->set($client, 'sessions', []);
+        $this->assertSame(['session' => ['id' => 'session']], $sessions);
+        $this->assertConnectionContextCleared($client);
         $this->assertTrue($this->get($client, 'isConnected'));
+    }
+
+    public function testSuccessfulSendRecoveryPreservesTransactionSessionForCommit(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->receives = [[
+            'result' => $this->frame([
+                'ok' => 1.0,
+                'id' => ['id' => new Binary(str_repeat("\1", 16), Binary::TYPE_GENERIC)],
+            ]),
+            'error' => 0,
+        ]];
+        $client = $this->reconnectingClient($transport);
+        $this->set($client, 'isConnected', true);
+        $session = $client->startSession();
+        $this->assertTrue($client->startTransaction($session));
+
+        $transport->sends = [['result' => false, 'error' => 11]];
+        $transport->receives = [
+            ['result' => $this->frame(['ok' => 1.0]), 'error' => 0],
+            ['result' => $this->frame(['ok' => 1.0]), 'error' => 0],
+        ];
+
+        $operation = $client->query(['ping' => 1, 'session' => $session]);
+        $commit = $client->commitTransaction($session);
+
+        $this->assertSame(1.0, $operation->ok);
+        $this->assertSame(1.0, $commit->ok);
+        $sessions = $this->get($client, 'sessions');
+        $this->set($client, 'sessions', []);
+        $this->assertSame(Client::TRANSACTION_COMMITTED, $sessions[$session['sessionId']]['state']);
     }
 
     public function testCoroutineSendFailureHardClosesBeforeFreshFullMessageRetry(): void
@@ -326,6 +363,7 @@ final class ClientTest extends TestCase
             ['result' => false, 'error' => 0],
         ];
         $client = $this->reconnectingClient($transport);
+        $this->seedState($client);
 
         try {
             $client->send('complete-message');
@@ -335,6 +373,7 @@ final class ClientTest extends TestCase
         }
 
         $this->assertSame([[true], [true]], $transport->closes);
+        $this->assertStateCleared($client);
     }
 
     public function testRetryShortSendHardClosesReplacementTransport(): void
@@ -346,6 +385,7 @@ final class ClientTest extends TestCase
         ];
         $transport->receives = [['result' => $this->frame(['ok' => 1.0]), 'error' => 0]];
         $client = $this->reconnectingClient($transport);
+        $this->seedState($client);
 
         try {
             $client->send('complete-message');
@@ -355,6 +395,26 @@ final class ClientTest extends TestCase
         }
 
         $this->assertSame(2, $transport->closes);
+        $this->assertStateCleared($client);
+    }
+
+    public function testFailedReconnectDoesNotRestoreSessions(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->sends = [['result' => false, 'error' => 11]];
+        $transport->connectionResults = [false];
+        $client = $this->client($transport);
+        $this->seedState($client);
+
+        try {
+            $client->send('complete-message');
+            $this->fail('Expected reconnect failure');
+        } catch (Exception $exception) {
+            $this->assertStringContainsString('Failed to connect to MongoDB', $exception->getMessage());
+        }
+
+        $this->assertSame([[true], [true]], $transport->closes);
+        $this->assertStateCleared($client);
     }
 
     public function testImpossibleFrameLengthHardClosesTransport(): void
@@ -393,6 +453,21 @@ final class ClientTest extends TestCase
         $this->assertSame(1, $transport->closes);
     }
 
+    public function testOpReplyIsRejectedByOpMsgParser(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->receives = [[
+            'result' => pack('V*', 36, 1, 0, 1, 0, 0, 0, 0, 0),
+            'error' => 0,
+        ]];
+        $client = $this->client($transport);
+
+        $exception = $this->receiveException($client);
+
+        $this->assertStringContainsString('Invalid response operation code: 1', $exception->getMessage());
+        $this->assertSame([[true]], $transport->closes);
+    }
+
     public function testDecodedMongoCommandErrorDoesNotCloseTransport(): void
     {
         $transport = new SyncTransportDouble();
@@ -423,6 +498,11 @@ final class ClientTest extends TestCase
     private function assertContextCleared(Client $client): void
     {
         $this->assertSame([], $this->get($client, 'sessions'));
+        $this->assertConnectionContextCleared($client);
+    }
+
+    private function assertConnectionContextCleared(Client $client): void
+    {
         $this->assertNull($this->get($client, 'clusterTime'));
         $this->assertNull($this->get($client, 'operationTime'));
         $this->assertNull($this->get($client, 'replicaSet'));

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -227,6 +227,21 @@ final class ClientTest extends TestCase
         $this->assertSame([], $transport->closes);
     }
 
+    public function testErroredEmptyReceiveHardClosesTransport(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->receives = [['result' => '', 'error' => 11]];
+        $client = $this->client($transport);
+        $this->seedState($client);
+
+        $exception = $this->receiveException($client);
+
+        $this->assertSame(11601, $exception->getCode());
+        $this->assertStringContainsString('errCode=11', $exception->getMessage());
+        $this->assertSame([[true]], $transport->closes);
+        $this->assertStateCleared($client);
+    }
+
     public function testReceiveDeadlineHardClosesTransport(): void
     {
         $transport = new SyncTransportDouble();

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,0 +1,481 @@
+<?php
+
+namespace Utopia\Tests;
+
+use MongoDB\BSON\Document;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+use Swoole\Client as SwooleClient;
+use Swoole\Coroutine\Client as CoroutineClient;
+use Utopia\Mongo\Auth;
+use Utopia\Mongo\Client;
+use Utopia\Mongo\Exception;
+
+trait TransportDouble
+{
+    public bool $open = true;
+    public array $connects = [];
+    public array $events = [];
+    public array $receives = [];
+    public array $sends = [];
+    public array $writes = [];
+
+    private function connectTransport(string $host, int $port, float $timeout, int $flags): bool
+    {
+        $this->events[] = ['connect', $host, $port, $timeout, $flags];
+        $this->connects[] = [$host, $port, $timeout, $flags];
+        $this->open = true;
+
+        return true;
+    }
+
+    private function receiveTransport(): string|false
+    {
+        $this->events[] = ['receive'];
+        $receive = array_shift($this->receives) ?? ['result' => '', 'error' => 0];
+        $this->errCode = $receive['error'];
+
+        return $receive['result'];
+    }
+
+    private function sendTransport(string $data): int|false
+    {
+        $this->events[] = ['send', $data];
+        $this->writes[] = $data;
+        $send = array_shift($this->sends) ?? ['result' => strlen($data), 'error' => 0];
+        $this->errCode = $send['error'];
+
+        return $send['result'];
+    }
+}
+
+final class SyncTransportDouble extends SwooleClient
+{
+    use TransportDouble;
+
+    public array $closes = [];
+
+    public function __construct()
+    {
+    }
+
+    public function close(bool $force = false): bool
+    {
+        $this->events[] = ['close', $force];
+        $this->closes[] = [$force];
+        $this->open = false;
+
+        return true;
+    }
+
+    public function connect(string $host, int $port = 0, float $timeout = 0.5, int $sock_flag = 0): bool
+    {
+        return $this->connectTransport($host, $port, $timeout, $sock_flag);
+    }
+
+    public function isConnected(): bool
+    {
+        return $this->open;
+    }
+
+    public function recv(int $size = 65535, int $flag = 0): string|false
+    {
+        return $this->receiveTransport();
+    }
+
+    public function send(string $data, int $flag = 0): int|false
+    {
+        return $this->sendTransport($data);
+    }
+}
+
+final class CoroutineTransportDouble extends CoroutineClient
+{
+    use TransportDouble;
+
+    public int $closes = 0;
+
+    public function __construct()
+    {
+    }
+
+    public function close(): bool
+    {
+        $this->events[] = ['close'];
+        $this->closes++;
+        $this->open = false;
+
+        return true;
+    }
+
+    public function connect(string $host, int $port = 0, float $timeout = 0.5, int $sock_flag = 0): bool
+    {
+        return $this->connectTransport($host, $port, $timeout, $sock_flag);
+    }
+
+    public function isConnected(): bool
+    {
+        return $this->open;
+    }
+
+    public function recv(float $timeout = 0): string|false
+    {
+        return $this->receiveTransport();
+    }
+
+    public function send(string $data, float $timeout = 0): int|false
+    {
+        return $this->sendTransport($data);
+    }
+}
+
+final class AuthenticationDouble extends Auth
+{
+    public function __construct()
+    {
+    }
+
+    public function continue($data): array
+    {
+        return [['ping' => 1], 'admin'];
+    }
+
+    public function start(): array
+    {
+        return [['ping' => 1], 'admin'];
+    }
+}
+
+final class ReconnectingClient extends Client
+{
+    public SwooleClient|CoroutineClient $transport;
+
+    public function connect(): self
+    {
+        $this->transport->connect('mongo', 27017, 30.0);
+        $connection = new ReflectionProperty(Client::class, 'isConnected');
+        $connection->setAccessible(true);
+        $connection->setValue($this, true);
+
+        return $this;
+    }
+}
+
+final class ClientTest extends TestCase
+{
+    public function testConnectPassesConfiguredTimeout(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->open = false;
+        $transport->receives = [
+            ['result' => $this->frame(['ok' => 1.0]), 'error' => 0],
+            ['result' => $this->frame(['ok' => 1.0]), 'error' => 0],
+        ];
+        $client = $this->client($transport, timeout: 7.5);
+        $this->set($client, 'auth', new AuthenticationDouble());
+
+        $client->connect();
+
+        $this->assertSame([['mongo', 27017, 7.5, 0]], $transport->connects);
+    }
+
+    public function testSyncReceiveFailureHardClosesAndClearsState(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->receives = [['result' => false, 'error' => 11]];
+        $client = $this->client($transport);
+        $this->seedState($client);
+
+        $exception = $this->receiveException($client);
+
+        $this->assertSame(11601, $exception->getCode());
+        $this->assertStringContainsString('errCode=11', $exception->getMessage());
+        $this->assertSame([[true]], $transport->closes);
+        $this->assertSame([], $transport->connects);
+        $this->assertStateCleared($client);
+    }
+
+    public function testCoroutineReceiveFailureHardClosesAndClearsState(): void
+    {
+        $transport = new CoroutineTransportDouble();
+        $transport->receives = [['result' => false, 'error' => 11]];
+        $client = $this->client($transport);
+        $this->seedState($client);
+
+        $exception = $this->receiveException($client);
+
+        $this->assertSame(11601, $exception->getCode());
+        $this->assertStringContainsString('errCode=11', $exception->getMessage());
+        $this->assertSame(1, $transport->closes);
+        $this->assertSame([], $transport->connects);
+        $this->assertStateCleared($client);
+    }
+
+    public function testTransientEmptyReceiveContinuesWithoutClosing(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->receives = [
+            ['result' => '', 'error' => 0],
+            ['result' => $this->frame(['ok' => 1.0]), 'error' => 0],
+        ];
+        $client = $this->client($transport);
+
+        $result = $this->receive($client);
+
+        $this->assertSame(1.0, $result->ok);
+        $this->assertSame([], $transport->closes);
+    }
+
+    public function testReceiveDeadlineHardClosesTransport(): void
+    {
+        $transport = new SyncTransportDouble();
+        $client = $this->client($transport, timeout: 0.0001);
+
+        $exception = $this->receiveException($client);
+
+        $this->assertSame(11601, $exception->getCode());
+        $this->assertSame([[true]], $transport->closes);
+    }
+
+    public function testSyncSendFailureHardClosesBeforeFreshFullMessageRetry(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->sends = [['result' => false, 'error' => 11]];
+        $transport->receives = [['result' => $this->frame(['ok' => 1.0]), 'error' => 0]];
+        $client = $this->reconnectingClient($transport);
+        $this->seedState($client);
+
+        $result = $client->send('complete-message');
+
+        $this->assertSame(1.0, $result->ok);
+        $this->assertSame(['complete-message', 'complete-message'], $transport->writes);
+        $this->assertSame(
+            ['send', 'close', 'connect', 'send', 'receive'],
+            array_column($transport->events, 0)
+        );
+        $this->assertSame([[true]], $transport->closes);
+        $this->assertContextCleared($client);
+        $this->assertTrue($this->get($client, 'isConnected'));
+    }
+
+    public function testCoroutineSendFailureHardClosesBeforeFreshFullMessageRetry(): void
+    {
+        $transport = new CoroutineTransportDouble();
+        $transport->sends = [['result' => false, 'error' => 11]];
+        $transport->receives = [['result' => $this->frame(['ok' => 1.0]), 'error' => 0]];
+        $client = $this->reconnectingClient($transport);
+
+        $result = $client->send('complete-message');
+
+        $this->assertSame(1.0, $result->ok);
+        $this->assertSame(['complete-message', 'complete-message'], $transport->writes);
+        $this->assertSame(
+            ['send', 'close', 'connect', 'send', 'receive'],
+            array_column($transport->events, 0)
+        );
+        $this->assertSame(1, $transport->closes);
+    }
+
+    public function testSyncShortSendHardClosesBeforeRetry(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->sends = [['result' => 4, 'error' => 0]];
+        $transport->receives = [['result' => $this->frame(['ok' => 1.0]), 'error' => 0]];
+        $client = $this->reconnectingClient($transport);
+
+        $client->send('complete-message');
+
+        $this->assertSame([[true]], $transport->closes);
+        $this->assertSame(['complete-message', 'complete-message'], $transport->writes);
+    }
+
+    public function testCoroutineShortSendHardClosesBeforeRetry(): void
+    {
+        $transport = new CoroutineTransportDouble();
+        $transport->sends = [['result' => 4, 'error' => 0]];
+        $transport->receives = [['result' => $this->frame(['ok' => 1.0]), 'error' => 0]];
+        $client = $this->reconnectingClient($transport);
+
+        $client->send('complete-message');
+
+        $this->assertSame(1, $transport->closes);
+        $this->assertSame(['complete-message', 'complete-message'], $transport->writes);
+    }
+
+    public function testRetryFailureHardClosesReplacementTransport(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->sends = [
+            ['result' => false, 'error' => 11],
+            ['result' => false, 'error' => 0],
+        ];
+        $client = $this->reconnectingClient($transport);
+
+        try {
+            $client->send('complete-message');
+            $this->fail('Expected send failure');
+        } catch (Exception $exception) {
+            $this->assertSame(11, $exception->getCode());
+        }
+
+        $this->assertSame([[true], [true]], $transport->closes);
+    }
+
+    public function testRetryShortSendHardClosesReplacementTransport(): void
+    {
+        $transport = new CoroutineTransportDouble();
+        $transport->sends = [
+            ['result' => false, 'error' => 11],
+            ['result' => 4, 'error' => 0],
+        ];
+        $transport->receives = [['result' => $this->frame(['ok' => 1.0]), 'error' => 0]];
+        $client = $this->reconnectingClient($transport);
+
+        try {
+            $client->send('complete-message');
+            $this->fail('Expected send failure');
+        } catch (Exception $exception) {
+            $this->assertSame(11, $exception->getCode());
+        }
+
+        $this->assertSame(2, $transport->closes);
+    }
+
+    public function testImpossibleFrameLengthHardClosesTransport(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->receives = [['result' => pack('V', 20), 'error' => 0]];
+        $client = $this->client($transport);
+
+        $exception = $this->receiveException($client);
+
+        $this->assertStringContainsString('Invalid response length', $exception->getMessage());
+        $this->assertSame([[true]], $transport->closes);
+    }
+
+    public function testOverlongFrameHardClosesTransport(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->receives = [['result' => pack('V*', 21, 1, 0, 2013, 0) . "\0x", 'error' => 0]];
+        $client = $this->client($transport);
+
+        $exception = $this->receiveException($client);
+
+        $this->assertStringContainsString('Response length mismatch', $exception->getMessage());
+        $this->assertSame([[true]], $transport->closes);
+    }
+
+    public function testInvalidBsonHardClosesCoroutineTransport(): void
+    {
+        $transport = new CoroutineTransportDouble();
+        $transport->receives = [['result' => pack('V*', 26, 1, 0, 2013, 0) . "\0abcde", 'error' => 0]];
+        $client = $this->client($transport);
+
+        $exception = $this->receiveException($client);
+
+        $this->assertStringContainsString('BSON', $exception->getMessage());
+        $this->assertSame(1, $transport->closes);
+    }
+
+    public function testDecodedMongoCommandErrorDoesNotCloseTransport(): void
+    {
+        $transport = new SyncTransportDouble();
+        $transport->receives = [[
+            'result' => $this->frame([
+                'ok' => 0.0,
+                'errmsg' => 'duplicate key',
+                'code' => 11000,
+                'codeName' => 'DuplicateKey',
+            ]),
+            'error' => 0,
+        ]];
+        $client = $this->client($transport);
+
+        $exception = $this->receiveException($client);
+
+        $this->assertSame(11000, $exception->getCode());
+        $this->assertSame([], $transport->closes);
+        $this->assertTrue($transport->open);
+    }
+
+    private function assertStateCleared(Client $client): void
+    {
+        $this->assertFalse($this->get($client, 'isConnected'));
+        $this->assertContextCleared($client);
+    }
+
+    private function assertContextCleared(Client $client): void
+    {
+        $this->assertSame([], $this->get($client, 'sessions'));
+        $this->assertNull($this->get($client, 'clusterTime'));
+        $this->assertNull($this->get($client, 'operationTime'));
+        $this->assertNull($this->get($client, 'replicaSet'));
+    }
+
+    private function client(SwooleClient|CoroutineClient $transport, float $timeout = 0.05): Client
+    {
+        $client = new Client('testing', 'mongo', 27017, 'root', 'example', timeout: $timeout);
+        $this->set($client, 'client', $transport);
+
+        return $client;
+    }
+
+    private function frame(array $document): string
+    {
+        $bson = (string) Document::fromPHP($document);
+
+        return pack('V*', 21 + strlen($bson), 1, 0, 2013, 0) . "\0" . $bson;
+    }
+
+    private function get(Client $client, string $property): mixed
+    {
+        $reflection = new ReflectionProperty(Client::class, $property);
+        $reflection->setAccessible(true);
+
+        return $reflection->getValue($client);
+    }
+
+    private function receive(Client $client): mixed
+    {
+        $reflection = new ReflectionMethod(Client::class, 'receive');
+        $reflection->setAccessible(true);
+
+        return $reflection->invoke($client);
+    }
+
+    private function receiveException(Client $client): Exception
+    {
+        try {
+            $this->receive($client);
+            $this->fail('Expected receive failure');
+        } catch (Exception $exception) {
+            return $exception;
+        }
+    }
+
+    private function reconnectingClient(SwooleClient|CoroutineClient $transport): ReconnectingClient
+    {
+        $client = new ReconnectingClient('testing', 'mongo', 27017, 'root', 'example');
+        $client->transport = $transport;
+        $this->set($client, 'client', $transport);
+
+        return $client;
+    }
+
+    private function seedState(Client $client): void
+    {
+        $this->set($client, 'isConnected', true);
+        $this->set($client, 'sessions', ['session' => ['id' => 'session']]);
+        $this->set($client, 'clusterTime', (object) ['time' => 1]);
+        $this->set($client, 'operationTime', (object) ['time' => 2]);
+        $this->set($client, 'replicaSet', true);
+    }
+
+    private function set(Client $client, string $property, mixed $value): void
+    {
+        $reflection = new ReflectionProperty(Client::class, $property);
+        $reflection->setAccessible(true);
+        $reflection->setValue($client, $value);
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -262,7 +262,7 @@ final class ClientTest extends TestCase
         $transport->sends = [['result' => false, 'error' => 11]];
         $transport->receives = [['result' => $this->frame(['ok' => 1.0]), 'error' => 0]];
         $client = $this->reconnectingClient($transport);
-        $this->seedState($client);
+        $this->seedConnectionContext($client);
 
         $result = $client->send('complete-message');
 
@@ -273,9 +273,7 @@ final class ClientTest extends TestCase
             array_column($transport->events, 0)
         );
         $this->assertSame([[true]], $transport->closes);
-        $sessions = $this->get($client, 'sessions');
-        $this->set($client, 'sessions', []);
-        $this->assertSame(['session' => ['id' => 'session']], $sessions);
+        $this->assertSame([], $this->get($client, 'sessions'));
         $this->assertConnectionContextCleared($client);
         $this->assertTrue($this->get($client, 'isConnected'));
     }
@@ -299,16 +297,19 @@ final class ClientTest extends TestCase
         $transport->receives = [
             ['result' => $this->frame(['ok' => 1.0]), 'error' => 0],
             ['result' => $this->frame(['ok' => 1.0]), 'error' => 0],
+            ['result' => $this->frame(['ok' => 1.0]), 'error' => 0],
         ];
 
         $operation = $client->query(['ping' => 1, 'session' => $session]);
         $commit = $client->commitTransaction($session);
+        $sessions = $this->get($client, 'sessions');
+        $ended = $client->endSessions([$session]);
 
         $this->assertSame(1.0, $operation->ok);
         $this->assertSame(1.0, $commit->ok);
-        $sessions = $this->get($client, 'sessions');
-        $this->set($client, 'sessions', []);
+        $this->assertSame(1.0, $ended->ok);
         $this->assertSame(Client::TRANSACTION_COMMITTED, $sessions[$session['sessionId']]['state']);
+        $this->assertSame([], $this->get($client, 'sessions'));
     }
 
     public function testCoroutineSendFailureHardClosesBeforeFreshFullMessageRetry(): void
@@ -560,8 +561,13 @@ final class ClientTest extends TestCase
 
     private function seedState(Client $client): void
     {
-        $this->set($client, 'isConnected', true);
+        $this->seedConnectionContext($client);
         $this->set($client, 'sessions', ['session' => ['id' => 'session']]);
+    }
+
+    private function seedConnectionContext(Client $client): void
+    {
+        $this->set($client, 'isConnected', true);
         $this->set($client, 'clusterTime', (object) ['time' => 1]);
         $this->set($client, 'operationTime', (object) ['time' => 2]);
         $this->set($client, 'replicaSet', true);


### PR DESCRIPTION
## Summary

- hard-close failed sync and coroutine transports before reconnecting so pooled sockets cannot be reused
- retry failed or partial writes once on a freshly authenticated connection
- clear connection-scoped session, causal-consistency, and replica-set state after transport loss
- apply the configured timeout to connect and invalidate malformed wire responses

## Validation

- composer format
- composer lint
- composer check
- composer test (43 tests, 157 assertions)
- focused transport regressions (15 tests, 53 assertions)
- PHP 8.0 syntax checks
- Swoole 5.1.2 and 6.2.1 connect/close signature checks