### PR TITLE
fix(client): keep an empty nested object out of the array flattener

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1694,6 +1694,8 @@ class Client
     /**
      * Convert an object (stdClass) to an assoc array.
      *
+     * A nested object with no properties stays a stdClass, so it re-encodes as {} and not as [].
+     *
      * @param mixed $obj
      * @return array|null
      */
@@ -1703,18 +1705,25 @@ class Client
             return null;
         }
 
-        if (is_object($obj) || is_array($obj)) {
-            $ret = (array)$obj;
-            foreach ($ret as $key => $item) {
-                if ($item instanceof stdClass || is_array($item)) {
-                    $ret[$key] = $this->toArray($item);
-                }
-            }
-
-            return $ret;
+        if (!is_object($obj) && !is_array($obj)) {
+            return [$obj];
         }
 
-        return [$obj];
+        $ret = (array)$obj;
+
+        foreach ($ret as $key => $item) {
+            if ($item instanceof stdClass) {
+                $ret[$key] = (array)$item === [] ? $item : $this->toArray($item);
+
+                continue;
+            }
+
+            if (is_array($item)) {
+                $ret[$key] = $this->toArray($item);
+            }
+        }
+
+        return $ret;
     }
 
     private function cleanFilters($filters): array

--- a/tests/MongoTest.php
+++ b/tests/MongoTest.php
@@ -393,6 +393,57 @@ class MongoTest extends TestCase
         self::assertEquals([42], $client->toArray(42));
     }
 
+    public function testEmptyObjectSurvivesToArray()
+    {
+        $client = $this->getDatabase();
+
+        $created = $client->insert('movies_empty_object', [
+            '_id' => 'empty-object-1',
+            'empty' => new \stdClass(),
+            'inner' => (object)['nested' => new \stdClass()],
+            'list' => [new \stdClass(), (object)['x' => 1]],
+            'filled' => (object)['a' => 1],
+            'emptyList' => [],
+        ]);
+
+        self::assertSame('{}', json_encode($created['empty']), 'insert() response flattened an empty object');
+        self::assertSame('{"nested":{}}', json_encode($created['inner']), 'insert() response flattened a nested empty object');
+        self::assertSame('[{},{"x":1}]', json_encode($created['list']), 'insert() response flattened an empty object inside a list');
+        self::assertSame('{"a":1}', json_encode($created['filled']));
+        self::assertSame('[]', json_encode($created['emptyList']), 'insert() response turned an empty array into an object');
+
+        self::assertIsArray($created['inner'], 'non-empty objects must still be associative arrays');
+        self::assertSame(['a' => 1], $created['filled'], 'non-empty objects must still be associative arrays');
+
+        $batch = $client->insertMany('movies_empty_object', [[
+            '_id' => 'empty-object-2',
+            'empty' => new \stdClass(),
+            'inner' => (object)['nested' => new \stdClass()],
+            'list' => [new \stdClass(), (object)['x' => 1]],
+        ]]);
+
+        self::assertSame('{}', json_encode($batch[0]['empty']), 'insertMany() response flattened an empty object');
+        self::assertSame('{"nested":{}}', json_encode($batch[0]['inner']), 'insertMany() response flattened a nested empty object');
+        self::assertSame('[{},{"x":1}]', json_encode($batch[0]['list']), 'insertMany() response flattened an empty object inside a list');
+
+        $read = $client->toArray($client->find('movies_empty_object', ['_id' => 'empty-object-1'])->cursor->firstBatch[0]);
+
+        self::assertSame('{}', json_encode($read['empty']), 'read path flattened an empty object');
+        self::assertSame('{"nested":{}}', json_encode($read['inner']), 'read path flattened a nested empty object');
+        self::assertSame('[{},{"x":1}]', json_encode($read['list']), 'read path flattened an empty object inside a list');
+        self::assertSame('{"a":1}', json_encode($read['filled']));
+        self::assertSame('[]', json_encode($read['emptyList']), 'read path turned an empty array into an object');
+
+        $last = $client->lastDocument('movies_empty_object');
+
+        self::assertSame('{}', json_encode($last['empty']), 'lastDocument() flattened an empty object');
+        self::assertSame('{"nested":{}}', json_encode($last['inner']), 'lastDocument() flattened a nested empty object');
+
+        self::assertSame([], $client->toArray(new \stdClass()), 'toArray() returns ?array, so only nested values change shape');
+
+        $client->dropCollection('movies_empty_object');
+    }
+
     public function testCountMethod()
     {
         $collectionName = 'count_test';


### PR DESCRIPTION
## What

An empty JSON object stored in a document attribute was served back as an empty array.

`Client::toArray()` recursively cast every nested `stdClass` to an array, and `(array) new \stdClass()` is `[]`. So an attribute holding `{}` came back as `[]`, an attribute holding `{"inner": {}}` came back as `{"inner": []}`, and `{"arr": [{}, {"x": 1}]}` came back as `{"arr": [[], {"x": 1}]}`.

This is not only a read-path defect. `insert()` (line 922) and `insertMany()` (line 1000) both return `$this->toArray($docObj)`, and `insertMany()` is what `utopia-php/database`'s `Adapter/Mongo.php` `createDocuments` returns to the caller, so **the POST response body was already wrong even when storage was correct**. That is exactly what the production probe measured: the create response itself carried `[]`, every write returned 201, and nothing warned.

Measured on production 2026-08-12 against a dedicated Mongo-backed DocumentsDB and a Postgres-backed VectorsDB. Linear: https://linear.app/appwrite/issue/DAT-2310

## The change

`src/Client.php`, `toArray()` (lines 1694-1729): a nested object with no properties is left as the `stdClass` it already is, so it re-encodes as `{}`. Every non-empty object still becomes an associative array, so callers that iterate or key into the result are unaffected. Only the empty case changes shape.

Verified the BSON type before writing the condition rather than assuming it. This client decodes responses with `Document::fromBSON($bson)->toPHP()` and configures no typeMap, so on the required extension version an empty sub-document is a plain `stdClass` with zero properties, not `BSONDocument` and not an `ArrayObject` subclass:

```
ext: 2.1.1 php: 8.3.7
root: stdClass
  empty => stdClass props=0 exactStdClass=true
  inner => stdClass props=1 exactStdClass=true
  arr => array count=2
    [0] => stdClass props=0
    [1] => stdClass props=1
  filled => stdClass props=1 exactStdClass=true
  emptyArr => array count=0
```

A BSON array still decodes to a PHP `array`, so an empty *array* is not affected and must keep encoding as `[]`. The test pins that too.

Same shape of solution as the `toAssociative()` helper in https://github.com/utopia-php/monorepo/pull/123, which fixes the framework-level root cause: convert non-empty objects to arrays, keep empty ones.

## Regression test, seen red

`tests/MongoTest.php::testEmptyObjectSurvivesToArray`. It drives the public API only, against a real MongoDB 8 over the real wire protocol. No reflection, no doubles, so nothing in it can answer its own assertion.

It covers `insert()`, `insertMany()`, `find()` + `toArray()` and `lastDocument()`, and asserts both directions of the contract: empty objects encode as `{}`, non-empty objects are still associative arrays, and empty arrays are still `[]`.

The test was written first and run against unmodified `origin/main` on PHP 8.3.7 with `ext-mongodb` 2.1.1 (the version `composer.json` requires), MongoDB 8.0.

**Red, unmodified `src/`:**

```
PHPUnit 9.6.29 by Sebastian Bergmann and contributors.

F                                                                   1 / 1 (100%)

Time: 00:00.064, Memory: 4.00 MB

There was 1 failure:

1) Utopia\Tests\MongoTest::testEmptyObjectSurvivesToArray
insert() response flattened an empty object
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'{}'
+'[]'

/usr/src/code/tests/MongoTest.php:409

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

`phpunit.xml` sets `stopOnFailure="true"`, so only the first assertion is reported. To show the full breadth of the defect, here is the same set of shapes driven through the public API against unmodified `src/`, reproducing the production measurements exactly:

```
sent                       insert()         insertMany()     find() + toArray()
empty: {}                  []               []               []
inner: {"nested":{}}       {"nested":[]}    {"nested":[]}    {"nested":[]}
list: [{},{"x":1}]         [[],{"x":1}]     [[],{"x":1}]     [[],{"x":1}]
filled: {"a":1}            {"a":1}          {"a":1}          {"a":1}
emptyList: []              []               []               []
```

**Green, with the fix:**

```
PHPUnit 9.6.29 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:00.051, Memory: 4.00 MB

OK (1 test, 18 assertions)
```

And the same shapes:

```
sent                       insert()         insertMany()     find() + toArray()
empty: {}                  {}               {}               {}
inner: {"nested":{}}       {"nested":{}}    {"nested":{}}    {"nested":{}}
list: [{},{"x":1}]         [{},{"x":1}]     [{},{"x":1}]     [{},{"x":1}]
filled: {"a":1}            {"a":1}          {"a":1}          {"a":1}
emptyList: []              []               []               []
```

## Full suite, lint, static analysis

Full suite against a real MongoDB 8, PHP 8.3.7, `ext-mongodb` 2.1.1, in the repo's own `php83.Dockerfile` image:

```
OK (61 tests, 295 assertions)
```

`composer lint` (Pint, PSR-12) and `composer check` (PHPStan level 4 over `src`) both clean, run inside the same PHP 8.3 image:

```
    PASS   ........................................................... 9 files
 [OK] No errors
```

## Scope and seams

There are several flatteners stacked on top of each other. This PR fixes only the one site in this repo. `utopia-php/database` is fixed in its own PR, and the HTTP framework root cause is https://github.com/utopia-php/monorepo/pull/123, where nested empty JSON objects now decode to `\stdClass` while non-empty objects stay associative arrays, leaving the array-shaped contract unchanged.

Checked the immediate consumer for an assumption this change could break: `Adapter/Mongo.php::replaceInternalIdsKeys()` recurses on `is_array($value)` and otherwise passes the value through, so a property-less `stdClass` survives it untouched. There are no keys in an empty object to rename.

**Release order: `utopia-php/database` and `utopia-php/mongo` first, then `utopia-php/http`, then the cloud/CE bump.** All three flatteners have to be out before the end-to-end shape is correct.

No E2E test in this repo covers the cloud-to-edge-to-engine path this defect was measured on, so the end-to-end proof has to come from the cloud/CE side once all three releases land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty nested objects are now preserved correctly as `{}` when data is converted and re-encoded.
  * Arrays, non-empty objects, and scalar values continue to convert consistently.
  * Document retrieval now maintains the expected structure for empty objects and arrays.

* **Tests**
  * Added coverage for inserting, retrieving, and converting documents containing empty and non-empty objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->