### PR TITLE
fix(client): decode BSON int64 to native PHP integers

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1726,6 +1726,49 @@ class Client
         return $ret;
     }
 
+    /**
+     * Replace BSON Int64 wrappers with native PHP integers.
+     *
+     * MongoDB\BSON\Document::toPHP() decodes every 64-bit BSON integer as an
+     * Int64 object on all platforms, so any value outside the int32 range comes
+     * back wrapped. Callers expect plain PHP values, and an Int64 that survives
+     * into user code either fatals when array-accessed or degrades to 1 under an
+     * (int) cast. On 64-bit PHP the unwrap is lossless; on 32-bit builds the
+     * wrapper is the only representation that preserves precision, so it stays.
+     *
+     * @param mixed $value
+     * @param array<string, true> $skip Top-level keys to leave untouched
+     * @return mixed
+     */
+    private static function normalizeInt64(mixed $value, array $skip = []): mixed
+    {
+        if ($value instanceof Int64) {
+            return \PHP_INT_SIZE >= 8 ? (int)(string)$value : $value;
+        }
+
+        if (\is_array($value)) {
+            foreach ($value as $key => $item) {
+                $value[$key] = self::normalizeInt64($item);
+            }
+
+            return $value;
+        }
+
+        if ($value instanceof stdClass) {
+            foreach (\get_object_vars($value) as $key => $item) {
+                if (isset($skip[$key])) {
+                    continue;
+                }
+
+                $value->{$key} = self::normalizeInt64($item);
+            }
+
+            return $value;
+        }
+
+        return $value;
+    }
+
     private function cleanFilters($filters): array
     {
         $cleanedFilters = [];
@@ -1910,6 +1953,11 @@ class Client
             if (\is_array($result)) {
                 $result = (object)$result;
             }
+
+            // $clusterTime is echoed back to the server verbatim on subsequent
+            // commands, so its BSON types must survive intact — signature.keyId
+            // is an int64 the server rejects if it comes back as an int32.
+            $result = self::normalizeInt64($result, ['$clusterTime' => true]);
         } catch (\Throwable $error) {
             $this->invalidate();
             throw new Exception('Failed to parse BSON response: ' . $error->getMessage(), 0, $error);

--- a/tests/MongoTest.php
+++ b/tests/MongoTest.php
@@ -320,6 +320,53 @@ class MongoTest extends TestCase
         $client->dropCollection('movies_nested');
     }
 
+    public function testInt64ValuesDecodeToNativeIntegers()
+    {
+        $client = $this->getDatabase();
+
+        // Beyond the int32 range, so MongoDB stores these as BSON int64 and
+        // Document::toPHP() hands them back as MongoDB\BSON\Int64 wrappers.
+        $negative = -3408048000;
+        $positive = 3408048000;
+        $extreme = \PHP_INT_MAX;
+
+        try {
+            $client->insert('movies_int64', [
+                '_id' => 'int64-test-1',
+                'small' => -42,
+                'big' => $negative,
+                'list' => [$negative, -42, $positive, $extreme],
+                'nested' => ['deep' => ['value' => $negative]],
+            ]);
+
+            $result = $client->find('movies_int64', ['_id' => 'int64-test-1'])->cursor->firstBatch[0] ?? null;
+            self::assertNotNull($result);
+
+            self::assertIsInt($result->small);
+            self::assertSame(-42, $result->small);
+
+            self::assertIsInt($result->big);
+            self::assertSame($negative, $result->big);
+
+            self::assertIsInt($result->list[0]);
+            self::assertSame($negative, $result->list[0]);
+            self::assertSame(-42, $result->list[1]);
+            self::assertSame($positive, $result->list[2]);
+            self::assertSame($extreme, $result->list[3]);
+
+            self::assertIsInt($result->nested->deep->value);
+            self::assertSame($negative, $result->nested->deep->value);
+
+            // toArray() must carry the native integers through untouched.
+            $array = $client->toArray($result);
+            self::assertSame($negative, $array['big']);
+            self::assertSame([$negative, -42, $positive, $extreme], $array['list']);
+            self::assertSame($negative, $array['nested']['deep']['value']);
+        } finally {
+            $client->dropCollection('movies_int64');
+        }
+    }
+
     public function testToArrayNestedConversion()
     {
         $client = $this->getDatabase();

--- a/tests/MongoTest.php
+++ b/tests/MongoTest.php
@@ -322,6 +322,13 @@ class MongoTest extends TestCase
 
     public function testInt64ValuesDecodeToNativeIntegers()
     {
+        if (\PHP_INT_SIZE < 8) {
+            // normalizeInt64() deliberately keeps the wrapper on 32-bit builds,
+            // where it is the only lossless representation, and the literals
+            // below would already be floats before reaching the driver.
+            self::markTestSkipped('Native int64 round-trip requires a 64-bit PHP build.');
+        }
+
         $client = $this->getDatabase();
 
         // Beyond the int32 range, so MongoDB stores these as BSON int64 and


### PR DESCRIPTION
Fixes the root cause of appwrite/appwrite#13175 — *BigInt[] Breaks MongoDb*.

## The bug

`MongoDB\BSON\Document::toPHP()` returns a `MongoDB\BSON\Int64` instance for **every** 64-bit BSON integer, on **all** platforms — [php.net documents this explicitly](https://www.php.net/manual/en/mongodb-bson-document.tophp.php), and since PECL mongodb 1.16.0 it is no longer 32-bit-only behaviour. Verified on both ext-mongodb 2.1.1 and 2.3.3. `Client::receive()` passed that tree straight through, so any stored value outside the int32 range reached callers as an object where a PHP `int` was expected.

Two consequences downstream:

- **Fatal on array access.** `Cannot use object of type MongoDB\BSON\Int64 as array` — the error in the linked issue. Store `[-3408048000]` in an `integer`/`bigint` array column and every subsequent read of the table 500s; the table is unusable from the Console until deleted.
- **Wrong JSON.** `json_encode()` on an `Int64` emits `{"$numberLong":"-3408048000"}` instead of a number, because the class implements `JsonSerializable` in extended-JSON form. Any value that reaches a response without passing through an explicit cast is served to clients in the wrong shape.

`[-42]` works because a small value is encoded as int32 and decodes to a plain `int` — which is why this arrived as a "big numbers break my table" report rather than a type bug.

## The fix

Unwrap at the decode boundary in `receive()`, so the whole client returns plain PHP values. On 64-bit PHP the unwrap is lossless. On 32-bit builds the wrapper is the only lossless representation, so it is left in place there.

### Why here, and not in each consumer

The alternative is teaching every consumer to recognise `Int64`. That leaves the same trap set for the next caller, and it does not help paths with no schema to consult — utopia-php/database normalises typed `integer`/`bigint` attributes in its `castingAfter()` step, but anything outside that (schemaless mode, and integers nested inside `object` columns) has no attribute list to drive a cast. The client's contract is "PHP values in, PHP values out"; `toArray()` already normalises nested `stdClass` for the same reason. This puts int64 on the same footing.

Cost is one recursive walk of a freshly-decoded (refcount-1) response, so array writes mutate in place rather than separating.

### `$clusterTime` is deliberately excluded

`$clusterTime` is stored verbatim by `updateCausalConsistency()` and echoed back to the server on every later command. Its `signature.keyId` is an int64; unwrapping it would let `Document::fromPHP()` re-encode a small value as an int32 and change the signed payload the server validates. Skipping that one top-level key keeps the wire representation byte-identical. This was the one non-obvious hazard in the change and is called out in a comment at the call site.

## Verification

**This repo**

- Added `MongoTest::testInt64ValuesDecodeToNativeIntegers` — a real round-trip through Mongo covering a scalar int64, an int64 inside a list, a mixed int32/int64 list, `PHP_INT_MAX`, and a nested document. **Seen red before the fix** (`Failed asserting that MongoDB\BSON\Int64 Object ('integer' => '-3408048000') is of type "int"`) and green after.
- Full suite: 62 tests, 310 assertions, OK. `TransactionTest` passes, which exercises the `$clusterTime` round-trip.
- `pint --test`: PASS. `phpstan`: no errors.

**Downstream, against utopia-php/database `main` with this client patched in**

- Reproduced a currently-live defect that `castingAfter()` does *not* cover: an `object` column holding `{"count": -3408048000}` reads back as `MongoDB\BSON\Int64` and serialises to `{"count":{"$numberLong":"-3408048000"}}`. With this fix: `int`, and `{"count":-3408048000}`.
- Full `MongoDBTest` e2e suite: 661 tests, 4962 assertions, 2 failures. Both are `testObjectAttribute*EmptyObject*` (`{}` vs `[]`) and are **unrelated to this change** — they reproduce identically with an unmodified client, and are caused by my local image having `utopia-php/cache` 4.0.1 baked in where that repo's lock requires 4.0.2.

## Review notes

- Greptile and CodeRabbit both flagged that the new test's unconditional native-int assertions contradicted the 32-bit branch. Correct, and fixed in 4875ed6 by declaring the 64-bit requirement via `markTestSkipped` rather than adding per-architecture expectations that this repo's CI can never execute. Reasoning is on the threads.
- An earlier revision of this description claimed an `(int)` cast on `Int64` yields `1` with a warning. That is wrong for ext-mongodb 2.x, which supplies a numeric cast handler — `(int)$int64` returns the correct value. The real failure modes are the two listed above.

## Not verified

- **32-bit PHP.** The `PHP_INT_SIZE` branch is reasoned, not exercised — CI has no 32-bit target, and the new test now skips there rather than pretending otherwise.
- **A small `signature.keyId`.** The `$clusterTime` exclusion is verified only in that transactions still pass with real (large) keyIds; I did not synthesise a keyId small enough to re-encode as int32 and confirm the server would have rejected it. The exclusion is a type-preservation guarantee, not a fix for an observed failure.
- **Propagation.** Landing this in Appwrite needs a `utopia-php/mongo` release, then `composer update` in utopia-php/database and appwrite. No code change is needed in either — both take this via the existing `1.*` constraint.
- **The "write should have been rejected" half of appwrite/appwrite#13175.** Not a bug: an Appwrite `integer` column created without explicit `min`/`max` gets `size = 8`, i.e. a 64-bit column, so `-3408048000` is a legal value. `Structure` does range-validate array elements when a narrower `max` is set. Only the read path was broken.